### PR TITLE
Add Backlog & Completed tabs, fix settings refresh and blocker removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ server/dist
 data/tasks.json
 data/server.log
 data/server-error.log
+server/data/
 *.tsbuildinfo

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -8,8 +8,10 @@ interface Props {
 
 const TABS: { key: TabName; label: string }[] = [
   { key: 'tasks', label: 'Tasks' },
+  { key: 'backlog', label: 'Backlog' },
   { key: 'ideas', label: 'Ideas' },
   { key: 'blocked', label: 'Blocked' },
+  { key: 'completed', label: 'Completed' },
   { key: 'archive', label: 'Archive' },
 ];
 

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -64,12 +64,10 @@ export default function TaskRow({
 
   const handleAddBlocker = async (data: { blockedByTaskId?: number; blockedUntilDate?: string }) => {
     await onAddBlocker(task.id, data);
-    await onReload();
   };
 
   const handleRemoveBlocker = async (blockerId: number) => {
     await onRemoveBlocker(blockerId, task.id);
-    await onReload();
   };
 
   return (

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -23,9 +23,18 @@ export default function TaskTable({
   onUpdate, onComplete, onUncomplete, onDelete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onReload,
 }: Props) {
+  const TAB_LABELS: Record<TabName, string> = {
+    tasks: 'tasks',
+    backlog: 'backlog tasks',
+    ideas: 'ideas',
+    blocked: 'blocked tasks',
+    completed: 'completed tasks',
+    archive: 'archived tasks',
+  };
+
   if (loading) return <div className="loading">Loading...</div>;
   if (tasks.length === 0) {
-    return <div className="empty">No {activeTab} yet.</div>;
+    return <div className="empty">No {TAB_LABELS[activeTab]} yet.</div>;
   }
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,4 @@ export interface Settings {
   globalTimeOffset: number;
 }
 
-export type TabName = 'tasks' | 'ideas' | 'blocked' | 'archive';
+export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive';


### PR DESCRIPTION
## Summary
- **Completed tab**: New tab showing finished tasks sorted by completion date, so completed tasks are no longer invisible
- **Backlog tab**: New tab for overflow tasks beyond the Top N setting, ensuring all prioritized tasks remain accessible
- **Settings auto-refresh**: Changing "Top N tasks shown" now immediately refreshes the task list and tab counts
- **Blocker removal fix**: Removing all blockers from a task in the Blocked tab now correctly moves the task out of the view
- **Improved empty states**: Each tab shows a descriptive empty message (e.g. "No backlog tasks yet.")
- **Gitignore**: Added `server/data/` to prevent runtime data from being tracked

## Test plan
- [ ] Set Top N to 2, confirm only 2 tasks in Tasks tab and remaining appear in Backlog
- [ ] Change Top N in Settings — confirm Tasks and Backlog refresh immediately
- [ ] Complete a task — confirm it moves to the Completed tab with correct count
- [ ] Undo a completed task — confirm it returns to Tasks/Backlog
- [ ] Add blockers to a task, navigate to Blocked tab, remove all blockers — confirm task disappears from Blocked tab without manual refresh
- [ ] Verify empty-state messages display correctly for each tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)