### PR TITLE
Enhance status field with multi-line editing and clickable links

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -113,7 +113,7 @@ taskRoutes.post('/tasks', (req, res) => {
   const task: Task = {
     id: data.nextTaskId++,
     title: title.trim(),
-    status: status || '',
+    status: typeof status === 'string' ? status.trim() : '',
     priority: priority || null,
     createdAt: now,
     updatedAt: now,
@@ -139,7 +139,7 @@ taskRoutes.put('/tasks/:id', (req, res) => {
 
   const { title, status, priority, isArchived } = req.body;
   if (title !== undefined) task.title = title.trim();
-  if (status !== undefined) task.status = status;
+  if (status !== undefined) task.status = typeof status === 'string' ? status.trim() : status;
   if (priority !== undefined) task.priority = priority || null;
   if (isArchived !== undefined) task.isArchived = isArchived;
   task.updatedAt = new Date().toISOString();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,6 @@ export default function App() {
         onLoadBlockers={loadForTask}
         onAddBlocker={handleAddBlocker}
         onRemoveBlocker={handleRemoveBlocker}
-        onReload={handleReload}
       />
     </div>
   );

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import type { Task, Settings, Blocker } from '../types';
 import { isStale } from '../utils/staleness';
+import { linkifyText } from '../utils/linkify';
 import BlockerList from './BlockerList';
 import BlockerForm from './BlockerForm';
 
@@ -16,7 +17,6 @@ interface Props {
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
-  onReload: () => Promise<void>;
 }
 
 const ROW_COLORS: Record<string, string> = {
@@ -28,16 +28,36 @@ const ROW_COLORS: Record<string, string> = {
 export default function TaskRow({
   task, settings, allTasks, blockers,
   onUpdate, onComplete, onUncomplete, onDelete,
-  onLoadBlockers, onAddBlocker, onRemoveBlocker, onReload,
+  onLoadBlockers, onAddBlocker, onRemoveBlocker,
 }: Props) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingStatus, setEditingStatus] = useState(false);
   const [titleValue, setTitleValue] = useState(task.title);
   const [statusValue, setStatusValue] = useState(task.status);
   const [showBlockers, setShowBlockers] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const stale = isStale(task.updatedAt, settings);
   const bgColor = stale ? '#e9d5ff' : (task.priority ? ROW_COLORS[task.priority] : '#f3f4f6');
+
+  // Sync status value from prop when not editing
+  useEffect(() => {
+    if (!editingStatus) {
+      setStatusValue(task.status);
+    }
+  }, [task.status, editingStatus]);
+
+  const autoResizeTextarea = useCallback((el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    el.style.height = el.scrollHeight + 'px';
+  }, []);
+
+  // Auto-resize when editing starts
+  useEffect(() => {
+    if (editingStatus && textareaRef.current) {
+      autoResizeTextarea(textareaRef.current);
+    }
+  }, [editingStatus, autoResizeTextarea]);
 
   const saveTitle = async () => {
     setEditingTitle(false);
@@ -50,9 +70,17 @@ export default function TaskRow({
 
   const saveStatus = async () => {
     setEditingStatus(false);
-    if (statusValue !== task.status) {
-      await onUpdate(task.id, { status: statusValue });
+    const trimmed = statusValue.trim();
+    if (trimmed !== task.status) {
+      await onUpdate(task.id, { status: trimmed });
+    } else {
+      setStatusValue(task.status);
     }
+  };
+
+  const cancelStatusEdit = () => {
+    setEditingStatus(false);
+    setStatusValue(task.status);
   };
 
   const toggleBlockers = async () => {
@@ -73,6 +101,17 @@ export default function TaskRow({
   return (
     <div className="task-row" style={{ backgroundColor: bgColor }}>
       <div className="task-row-main">
+        <select
+          value={task.priority || ''}
+          onChange={e => onUpdate(task.id, { priority: (e.target.value || null) as Task['priority'] })}
+          className="priority-select"
+        >
+          <option value="">Idea</option>
+          <option value="P0">P0</option>
+          <option value="P1">P1</option>
+          <option value="P2">P2</option>
+        </select>
+
         <div className="task-title" onClick={() => setEditingTitle(true)}>
           {editingTitle ? (
             <input
@@ -88,33 +127,6 @@ export default function TaskRow({
           )}
         </div>
 
-        <div className="task-status" onClick={() => setEditingStatus(true)}>
-          {editingStatus ? (
-            <input
-              autoFocus
-              value={statusValue}
-              onChange={e => setStatusValue(e.target.value)}
-              onBlur={saveStatus}
-              onKeyDown={e => e.key === 'Enter' && saveStatus()}
-              className="inline-edit"
-              placeholder="status..."
-            />
-          ) : (
-            <span className="status-text">{task.status || '—'}</span>
-          )}
-        </div>
-
-        <select
-          value={task.priority || ''}
-          onChange={e => onUpdate(task.id, { priority: (e.target.value || null) as Task['priority'] })}
-          className="priority-select"
-        >
-          <option value="">Idea</option>
-          <option value="P0">P0</option>
-          <option value="P1">P1</option>
-          <option value="P2">P2</option>
-        </select>
-
         <div className="task-actions">
           {task.completedAt ? (
             <button className="btn btn-sm" onClick={() => onUncomplete(task.id)}>Undo</button>
@@ -129,6 +141,52 @@ export default function TaskRow({
           </button>
           <button className="btn btn-sm btn-danger" onClick={() => onDelete(task.id)}>Delete</button>
         </div>
+      </div>
+
+      <div
+        className="task-status-section"
+        onClick={(e) => {
+          if ((e.target as HTMLElement).tagName === 'A') return;
+          setEditingStatus(true);
+        }}
+      >
+        {editingStatus ? (
+          <div className="status-edit-container">
+            <textarea
+              ref={textareaRef}
+              autoFocus
+              value={statusValue}
+              onChange={(e) => {
+                setStatusValue(e.target.value);
+                autoResizeTextarea(e.target);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                  e.preventDefault();
+                  saveStatus();
+                }
+                if (e.key === 'Escape') {
+                  cancelStatusEdit();
+                }
+              }}
+              className="inline-edit status-textarea"
+              placeholder="Add status or notes..."
+            />
+            <div className="status-edit-actions">
+              <button className="btn btn-sm btn-primary" onClick={saveStatus}>Save</button>
+              <button className="btn btn-sm" onClick={cancelStatusEdit}>Cancel</button>
+              <span className="status-edit-hint">Ctrl+Enter to save · Esc to cancel</span>
+            </div>
+          </div>
+        ) : (
+          <div className="status-display">
+            {task.status ? (
+              <span className="status-text">{linkifyText(task.status)}</span>
+            ) : (
+              <span className="status-placeholder">Click to add status...</span>
+            )}
+          </div>
+        )}
       </div>
 
       {showBlockers && (

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -15,13 +15,12 @@ interface Props {
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
-  onReload: () => Promise<void>;
 }
 
 export default function TaskTable({
   tasks, settings, allTasks, blockers, activeTab, loading,
   onUpdate, onComplete, onUncomplete, onDelete,
-  onLoadBlockers, onAddBlocker, onRemoveBlocker, onReload,
+  onLoadBlockers, onAddBlocker, onRemoveBlocker,
 }: Props) {
   const TAB_LABELS: Record<TabName, string> = {
     tasks: 'tasks',
@@ -53,7 +52,6 @@ export default function TaskTable({
           onLoadBlockers={onLoadBlockers}
           onAddBlocker={onAddBlocker}
           onRemoveBlocker={onRemoveBlocker}
-          onReload={onReload}
         />
       ))}
     </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -191,15 +191,66 @@ body {
   display: block;
 }
 
-.task-status {
-  width: 120px;
+/* Status section - full width below title row */
+.task-status-section {
   cursor: pointer;
-  flex-shrink: 0;
+  margin-top: 0.375rem;
+  padding-top: 0.375rem;
+}
+
+.status-display {
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .status-text {
   color: #6b7280;
   font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.status-text a {
+  color: #2563eb;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.status-text a:hover {
+  color: #1d4ed8;
+}
+
+.status-placeholder {
+  color: #d1d5db;
+  font-size: 0.8125rem;
+  font-style: italic;
+}
+
+.status-textarea {
+  width: 100%;
+  min-height: 2.5rem;
+  resize: none;
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding: 0.375rem 0.5rem;
+}
+
+.status-edit-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.status-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.status-edit-hint {
+  color: #9ca3af;
+  font-size: 0.75rem;
+  margin-left: auto;
 }
 
 .inline-edit {

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+const URL_REGEX = /(https?:\/\/[^\s<>"')\]]+)/g;
+
+export function linkifyText(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  URL_REGEX.lastIndex = 0;
+
+  while ((match = URL_REGEX.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const url = match[1];
+    parts.push(
+      <a
+        key={match.index}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {url}
+      </a>
+    );
+    lastIndex = URL_REGEX.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Summary
- **Card layout**: Status moved below title row, giving it full card width for multi-line content
- **Multi-line editing**: Replaced single-line input with auto-resizing textarea — Enter adds new lines, Ctrl+Enter saves, Esc cancels
- **Clickable links**: URLs in status text are auto-detected and rendered as blue clickable links (opens in new tab)
- **Improved UX**: Save/Cancel buttons with keyboard shortcut hints, italic placeholder for empty status
- **Server trimming**: Status is trimmed on both create and update endpoints
- **Cleanup**: Removed unused onReload prop from TaskRow/TaskTable

## Test plan
- [ ] Click a task's status area — textarea appears with Save/Cancel buttons and keyboard hint
- [ ] Type multi-line text using Enter, then save with Ctrl+Enter — newlines are preserved in display
- [ ] Type a URL (e.g. https://github.com), save — renders as a blue clickable link
- [ ] Click a link in the status — opens in new tab without triggering edit mode
- [ ] Press Escape while editing — reverts to original status text
- [ ] Verify empty status shows "Click to add status..." placeholder
- [ ] Verify existing single-line statuses still display correctly

Generated with [Claude Code](https://claude.com/claude-code)