### PR TITLE
Add soft-delete with Trash tab and permanent delete

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15,6 +15,7 @@ export interface Task {
   updatedAt: string;
   completedAt: string | null;
   isArchived: boolean;
+  isDeleted: boolean;
 }
 
 export interface Blocker {

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,9 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
     const text = await res.text();
     throw new Error(text || res.statusText);
   }
+  if (res.status === 204) {
+    return undefined as T;
+  }
   return res.json();
 }
 
@@ -21,7 +24,7 @@ export const fetchTasks = (tab: TabName) =>
 export const createTask = (data: { title: string; status?: string; priority?: string | null }) =>
   request<Task>('/tasks', { method: 'POST', body: JSON.stringify(data) });
 
-export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) =>
+export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) =>
   request<Task>(`/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) });
 
 export const completeTask = (id: number) =>
@@ -31,7 +34,10 @@ export const uncompleteTask = (id: number) =>
   request<Task>(`/tasks/${id}/uncomplete`, { method: 'POST' });
 
 export const deleteTask = (id: number) =>
-  request<void>(`/tasks/${id}`, { method: 'DELETE' });
+  request<Task>(`/tasks/${id}`, { method: 'DELETE' });
+
+export const permanentDeleteTask = (id: number) =>
+  request<void>(`/tasks/${id}?permanent=true`, { method: 'DELETE' });
 
 // Blockers
 export const fetchBlockers = (taskId: number) =>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -13,6 +13,7 @@ const TABS: { key: TabName; label: string }[] = [
   { key: 'blocked', label: 'Blocked' },
   { key: 'completed', label: 'Completed' },
   { key: 'archive', label: 'Archive' },
+  { key: 'trash', label: 'Trash' },
 ];
 
 export default function TabBar({ activeTab, onTabChange, counts }: Props) {

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -8,19 +8,20 @@ interface Props {
   blockers: Record<number, Blocker[]>;
   activeTab: TabName;
   loading: boolean;
-  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
+  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
   onDelete: (id: number) => Promise<void>;
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
+  onPermanentDelete: (id: number) => Promise<void>;
 }
 
 export default function TaskTable({
   tasks, settings, allTasks, blockers, activeTab, loading,
   onUpdate, onComplete, onUncomplete, onDelete,
-  onLoadBlockers, onAddBlocker, onRemoveBlocker,
+  onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete,
 }: Props) {
   const TAB_LABELS: Record<TabName, string> = {
     tasks: 'tasks',
@@ -29,6 +30,7 @@ export default function TaskTable({
     blocked: 'blocked tasks',
     completed: 'completed tasks',
     archive: 'archived tasks',
+    trash: 'deleted tasks',
   };
 
   if (loading) return <div className="loading">Loading...</div>;
@@ -52,6 +54,7 @@ export default function TaskTable({
           onLoadBlockers={onLoadBlockers}
           onAddBlocker={onAddBlocker}
           onRemoveBlocker={onRemoveBlocker}
+          onPermanentDelete={onPermanentDelete}
         />
       ))}
     </div>

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -23,7 +23,7 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
-  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => {
+  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) => {
     await api.updateTask(id, data);
     await reload();
   };
@@ -43,5 +43,10 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
-  return { tasks, loading, reload, create, update, complete, uncomplete, remove };
+  const permanentRemove = async (id: number) => {
+    await api.permanentDeleteTask(id);
+    await reload();
+  };
+
+  return { tasks, loading, reload, create, update, complete, uncomplete, remove, permanentRemove };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Task {
   updatedAt: string;
   completedAt: string | null;
   isArchived: boolean;
+  isDeleted: boolean;
 }
 
 export interface Blocker {
@@ -23,4 +24,4 @@ export interface Settings {
   globalTimeOffset: number;
 }
 
-export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive';
+export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive' | 'trash';


### PR DESCRIPTION
## Summary
- **Soft-delete**: Deleting a task now sets isDeleted=true instead of removing it from storage, allowing recovery
- **Trash tab**: New tab showing all soft-deleted tasks with Restore and Permanently Delete actions
- **Permanent delete**: Hard-deletes a task with a confirmation dialog; fixes 204 No Content response handling in the API client so the UI refreshes correctly
- **Filter updates**: All existing tabs (Tasks, Backlog, Ideas, Blocked, Completed, Archive) exclude soft-deleted tasks

## Test plan
- [ ] Delete a task and verify it disappears from its current tab
- [ ] Switch to Trash tab and verify the deleted task appears
- [ ] Click Restore on a trashed task and verify it returns to its original tab
- [ ] Click Permanently Delete, confirm the dialog, and verify the task is removed and the UI refreshes
- [ ] Verify deleted tasks do not appear in any non-Trash tab
- [ ] Verify Trash count badge updates correctly