### PR TITLE
Add server-side unit tests with Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vite": "^5.4.0",
-        "vite-plugin-pwa": "^0.19.0"
+        "vite-plugin-pwa": "^0.19.0",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -2431,6 +2432,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2494,6 +2501,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2502,6 +2519,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2653,6 +2676,93 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2757,6 +2867,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3029,6 +3148,15 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3493,6 +3621,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3612,6 +3746,15 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4989,6 +5132,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ]
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5075,6 +5228,12 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5793,6 +5952,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5868,6 +6033,12 @@
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5875,6 +6046,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6091,6 +6268,75 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6911,6 +7157,230 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -7026,6 +7496,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workbox-background-sync": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "node server/dist/index.js",
     "preview": "vite preview",
     "install-service": "node scripts/install-service.js",
-    "uninstall-service": "node scripts/uninstall-service.js"
+    "uninstall-service": "node scripts/uninstall-service.js",
+    "test": "vitest run --config vitest.config.server.ts",
+    "test:watch": "vitest --config vitest.config.server.ts"
   },
   "dependencies": {
     "express": "^4.18.0",
@@ -25,6 +27,7 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
     "vite": "^5.4.0",
-    "vite-plugin-pwa": "^0.19.0"
+    "vite-plugin-pwa": "^0.19.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/server/__tests__/blocker-routes.test.ts
+++ b/server/__tests__/blocker-routes.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeTask, makeBlocker, makeAppData, resetIdCounter } from './helpers.js';
+
+vi.mock('../storage.js', () => ({
+  readData: vi.fn(),
+  writeData: vi.fn(),
+}));
+
+import { readData, writeData } from '../storage.js';
+import { blockerRoutes } from '../routes/blockers.js';
+
+const mockedReadData = vi.mocked(readData);
+const mockedWriteData = vi.mocked(writeData);
+
+function findHandler(method: string, path: string) {
+  const layer = (blockerRoutes as any).stack.find((s: any) =>
+    s.route?.path === path && s.route?.methods[method]
+  );
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${path}`);
+  return layer.route.stack.find((s: any) => s.method === method).handle;
+}
+
+function mockReq(overrides: Record<string, any> = {}) {
+  return { params: {}, query: {}, body: {}, ...overrides };
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetIdCounter();
+});
+
+describe('GET /tasks/:id/blockers', () => {
+  const handler = findHandler('get', '/tasks/:id/blockers');
+
+  it('returns blockers for the specified taskId', () => {
+    const data = makeAppData({
+      blockers: [
+        makeBlocker({ id: 1, taskId: 5 }),
+        makeBlocker({ id: 2, taskId: 5 }),
+        makeBlocker({ id: 3, taskId: 10 }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '5' } }), res);
+
+    const result = res.json.mock.calls[0][0];
+    expect(result).toHaveLength(2);
+    expect(result.every((b: any) => b.taskId === 5)).toBe(true);
+  });
+
+  it('returns empty array when task has no blockers', () => {
+    const data = makeAppData({
+      blockers: [makeBlocker({ taskId: 10 })],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '5' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toEqual([]);
+  });
+});
+
+describe('POST /tasks/:id/blockers', () => {
+  const handler = findHandler('post', '/tasks/:id/blockers');
+
+  it('creates a blocker with correct defaults', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 })],
+      nextBlockerId: 50,
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    const blocker = res.json.mock.calls[0][0];
+    expect(blocker.id).toBe(50);
+    expect(blocker.taskId).toBe(1);
+    expect(blocker.blockedByTaskId).toBe(null);
+    expect(blocker.blockedUntilDate).toBe(null);
+    expect(blocker.resolved).toBe(false);
+  });
+
+  it('returns 404 when task does not exist', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' }, body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('accepts blockedByTaskId', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { blockedByTaskId: 5 } }), res);
+
+    expect(res.json.mock.calls[0][0].blockedByTaskId).toBe(5);
+  });
+
+  it('accepts blockedUntilDate', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { blockedUntilDate: '2025-06-01T00:00:00Z' } }), res);
+
+    expect(res.json.mock.calls[0][0].blockedUntilDate).toBe('2025-06-01T00:00:00Z');
+  });
+
+  it('increments nextBlockerId', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })], nextBlockerId: 10 });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: {} }), res);
+
+    expect(data.nextBlockerId).toBe(11);
+  });
+
+  it('calls writeData', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: {} }), res);
+
+    expect(mockedWriteData).toHaveBeenCalledWith(data);
+  });
+});
+
+describe('DELETE /blockers/:id', () => {
+  const handler = findHandler('delete', '/blockers/:id');
+
+  it('removes blocker and returns 204', () => {
+    const data = makeAppData({
+      blockers: [
+        makeBlocker({ id: 1 }),
+        makeBlocker({ id: 2 }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(data.blockers).toHaveLength(1);
+    expect(data.blockers[0].id).toBe(2);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('returns 404 when blocker does not exist', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('calls writeData on success', () => {
+    const data = makeAppData({
+      blockers: [makeBlocker({ id: 1 })],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(mockedWriteData).toHaveBeenCalledWith(data);
+  });
+});

--- a/server/__tests__/helpers.ts
+++ b/server/__tests__/helpers.ts
@@ -1,0 +1,51 @@
+import type { Task, Blocker, Settings, AppData } from '../storage.js';
+
+let idCounter = 1;
+
+export function makeTask(overrides: Partial<Task> = {}): Task {
+  const id = overrides.id ?? idCounter++;
+  const now = new Date().toISOString();
+  return {
+    id,
+    title: `Task ${id}`,
+    status: '',
+    priority: 'P1',
+    createdAt: now,
+    updatedAt: now,
+    completedAt: null,
+    isArchived: false,
+    isDeleted: false,
+    ...overrides,
+  };
+}
+
+export function makeBlocker(overrides: Partial<Blocker> = {}): Blocker {
+  const id = overrides.id ?? idCounter++;
+  return {
+    id,
+    taskId: 1,
+    blockedByTaskId: null,
+    blockedUntilDate: null,
+    resolved: false,
+    ...overrides,
+  };
+}
+
+export function makeAppData(overrides: Partial<AppData> = {}): AppData {
+  return {
+    tasks: [],
+    blockers: [],
+    settings: {
+      staleThresholdHours: 48,
+      topN: 20,
+      globalTimeOffset: 0,
+    },
+    nextTaskId: 100,
+    nextBlockerId: 100,
+    ...overrides,
+  };
+}
+
+export function resetIdCounter(): void {
+  idCounter = 1;
+}

--- a/server/__tests__/settings-routes.test.ts
+++ b/server/__tests__/settings-routes.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeAppData, resetIdCounter } from './helpers.js';
+
+vi.mock('../storage.js', () => ({
+  readData: vi.fn(),
+  writeData: vi.fn(),
+}));
+
+import { readData, writeData } from '../storage.js';
+import { settingsRoutes } from '../routes/settings.js';
+
+const mockedReadData = vi.mocked(readData);
+const mockedWriteData = vi.mocked(writeData);
+
+function findHandler(method: string, path: string) {
+  const layer = (settingsRoutes as any).stack.find((s: any) =>
+    s.route?.path === path && s.route?.methods[method]
+  );
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${path}`);
+  return layer.route.stack.find((s: any) => s.method === method).handle;
+}
+
+function mockReq(overrides: Record<string, any> = {}) {
+  return { params: {}, query: {}, body: {}, ...overrides };
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetIdCounter();
+});
+
+describe('GET /settings', () => {
+  const handler = findHandler('get', '/settings');
+
+  it('returns current settings', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq(), res);
+
+    const settings = res.json.mock.calls[0][0];
+    expect(settings.staleThresholdHours).toBe(48);
+    expect(settings.topN).toBe(20);
+    expect(settings.globalTimeOffset).toBe(0);
+  });
+});
+
+describe('PUT /settings', () => {
+  const handler = findHandler('put', '/settings');
+
+  it('updates only provided fields', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { topN: 10 } }), res);
+
+    const settings = res.json.mock.calls[0][0];
+    expect(settings.topN).toBe(10);
+    expect(settings.staleThresholdHours).toBe(48); // unchanged
+    expect(settings.globalTimeOffset).toBe(0); // unchanged
+  });
+
+  it('updates multiple fields at once', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { topN: 5, staleThresholdHours: 24 } }), res);
+
+    const settings = res.json.mock.calls[0][0];
+    expect(settings.topN).toBe(5);
+    expect(settings.staleThresholdHours).toBe(24);
+  });
+
+  it('updates globalTimeOffset', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { globalTimeOffset: 72 } }), res);
+
+    expect(res.json.mock.calls[0][0].globalTimeOffset).toBe(72);
+  });
+
+  it('calls writeData with updated data', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { topN: 15 } }), res);
+
+    expect(mockedWriteData).toHaveBeenCalledWith(data);
+    expect(data.settings.topN).toBe(15);
+  });
+
+  it('does not modify fields not in the request', () => {
+    const data = makeAppData();
+    const originalThreshold = data.settings.staleThresholdHours;
+    const originalOffset = data.settings.globalTimeOffset;
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { topN: 30 } }), res);
+
+    expect(data.settings.staleThresholdHours).toBe(originalThreshold);
+    expect(data.settings.globalTimeOffset).toBe(originalOffset);
+  });
+});

--- a/server/__tests__/task-logic.test.ts
+++ b/server/__tests__/task-logic.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { autoUnblock, hasUnresolvedBlockers, getPrioritizedTasks, PRIORITY_ORDER } from '../task-logic.js';
+import { makeTask, makeBlocker, makeAppData, resetIdCounter } from './helpers.js';
+
+beforeEach(() => {
+  resetIdCounter();
+});
+
+describe('PRIORITY_ORDER', () => {
+  it('orders P0 < P1 < P2', () => {
+    expect(PRIORITY_ORDER['P0']).toBeLessThan(PRIORITY_ORDER['P1']);
+    expect(PRIORITY_ORDER['P1']).toBeLessThan(PRIORITY_ORDER['P2']);
+  });
+});
+
+describe('hasUnresolvedBlockers', () => {
+  it('returns false when task has no blockers', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })] });
+    expect(hasUnresolvedBlockers(1, data)).toBe(false);
+  });
+
+  it('returns false when task has only resolved blockers', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 })],
+      blockers: [makeBlocker({ taskId: 1, resolved: true })],
+    });
+    expect(hasUnresolvedBlockers(1, data)).toBe(false);
+  });
+
+  it('returns true when task has an unresolved blocker', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 })],
+      blockers: [makeBlocker({ taskId: 1, resolved: false })],
+    });
+    expect(hasUnresolvedBlockers(1, data)).toBe(true);
+  });
+
+  it('ignores blockers belonging to other tasks', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 }), makeTask({ id: 2 })],
+      blockers: [makeBlocker({ taskId: 2, resolved: false })],
+    });
+    expect(hasUnresolvedBlockers(1, data)).toBe(false);
+  });
+});
+
+describe('autoUnblock', () => {
+  it('returns false when there are no blockers', () => {
+    const data = makeAppData();
+    expect(autoUnblock(data)).toBe(false);
+  });
+
+  it('returns false when all blockers are already resolved', () => {
+    const data = makeAppData({
+      blockers: [makeBlocker({ resolved: true })],
+    });
+    expect(autoUnblock(data)).toBe(false);
+  });
+
+  it('resolves a blocker whose date is in the past', () => {
+    const blocker = makeBlocker({
+      blockedUntilDate: '2020-01-01T00:00:00Z',
+      resolved: false,
+    });
+    const data = makeAppData({ blockers: [blocker] });
+
+    expect(autoUnblock(data)).toBe(true);
+    expect(blocker.resolved).toBe(true);
+  });
+
+  it('does not resolve a blocker whose date is in the future', () => {
+    const blocker = makeBlocker({
+      blockedUntilDate: '2099-01-01T00:00:00Z',
+      resolved: false,
+    });
+    const data = makeAppData({ blockers: [blocker] });
+
+    expect(autoUnblock(data)).toBe(false);
+    expect(blocker.resolved).toBe(false);
+  });
+
+  it('resolves a blocker whose blocking task is completed', () => {
+    const blockingTask = makeTask({ id: 10, completedAt: '2024-01-01T00:00:00Z' });
+    const blocker = makeBlocker({
+      taskId: 1,
+      blockedByTaskId: 10,
+      resolved: false,
+    });
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 }), blockingTask],
+      blockers: [blocker],
+    });
+
+    expect(autoUnblock(data)).toBe(true);
+    expect(blocker.resolved).toBe(true);
+  });
+
+  it('does not resolve a blocker whose blocking task is not completed', () => {
+    const blockingTask = makeTask({ id: 10, completedAt: null });
+    const blocker = makeBlocker({
+      taskId: 1,
+      blockedByTaskId: 10,
+      resolved: false,
+    });
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 }), blockingTask],
+      blockers: [blocker],
+    });
+
+    expect(autoUnblock(data)).toBe(false);
+    expect(blocker.resolved).toBe(false);
+  });
+
+  it('resolves only eligible blockers in a mixed scenario', () => {
+    const pastBlocker = makeBlocker({
+      id: 1,
+      blockedUntilDate: '2020-01-01T00:00:00Z',
+      resolved: false,
+    });
+    const futureBlocker = makeBlocker({
+      id: 2,
+      blockedUntilDate: '2099-01-01T00:00:00Z',
+      resolved: false,
+    });
+    const data = makeAppData({ blockers: [pastBlocker, futureBlocker] });
+
+    expect(autoUnblock(data)).toBe(true);
+    expect(pastBlocker.resolved).toBe(true);
+    expect(futureBlocker.resolved).toBe(false);
+  });
+
+  it('mutates the data object in place', () => {
+    const blocker = makeBlocker({
+      blockedUntilDate: '2020-01-01T00:00:00Z',
+      resolved: false,
+    });
+    const data = makeAppData({ blockers: [blocker] });
+
+    autoUnblock(data);
+    // Verify the original blocker object was mutated
+    expect(data.blockers[0].resolved).toBe(true);
+  });
+});
+
+describe('getPrioritizedTasks', () => {
+  describe('filtering', () => {
+    it('excludes tasks with null priority (ideas)', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, priority: null })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(0);
+    });
+
+    it('excludes archived tasks', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, isArchived: true })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(0);
+    });
+
+    it('excludes deleted tasks', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, isDeleted: true })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(0);
+    });
+
+    it('excludes completed tasks', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, completedAt: '2024-01-01T00:00:00Z' })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(0);
+    });
+
+    it('excludes tasks with unresolved blockers', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1 })],
+        blockers: [makeBlocker({ taskId: 1, resolved: false })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(0);
+    });
+
+    it('includes tasks that pass all criteria', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, priority: 'P1' })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(1);
+    });
+
+    it('includes tasks with resolved blockers', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1 })],
+        blockers: [makeBlocker({ taskId: 1, resolved: true })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(1);
+    });
+  });
+
+  describe('sorting', () => {
+    it('sorts P0 before P1 before P2', () => {
+      const data = makeAppData({
+        tasks: [
+          makeTask({ id: 1, priority: 'P2', createdAt: '2024-01-01T00:00:00Z' }),
+          makeTask({ id: 2, priority: 'P0', createdAt: '2024-01-02T00:00:00Z' }),
+          makeTask({ id: 3, priority: 'P1', createdAt: '2024-01-03T00:00:00Z' }),
+        ],
+      });
+      const result = getPrioritizedTasks(data);
+      expect(result.map(t => t.priority)).toEqual(['P0', 'P1', 'P2']);
+    });
+
+    it('sorts by createdAt ascending within same priority', () => {
+      const data = makeAppData({
+        tasks: [
+          makeTask({ id: 1, priority: 'P1', createdAt: '2024-03-01T00:00:00Z' }),
+          makeTask({ id: 2, priority: 'P1', createdAt: '2024-01-01T00:00:00Z' }),
+          makeTask({ id: 3, priority: 'P1', createdAt: '2024-02-01T00:00:00Z' }),
+        ],
+      });
+      const result = getPrioritizedTasks(data);
+      expect(result.map(t => t.id)).toEqual([2, 3, 1]);
+    });
+
+    it('is stable: changing updatedAt does not affect order', () => {
+      const data = makeAppData({
+        tasks: [
+          makeTask({ id: 1, priority: 'P1', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2025-12-01T00:00:00Z' }),
+          makeTask({ id: 2, priority: 'P1', createdAt: '2024-02-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' }),
+        ],
+      });
+      const result = getPrioritizedTasks(data);
+      // Task 1 was created earlier, so it comes first regardless of updatedAt
+      expect(result.map(t => t.id)).toEqual([1, 2]);
+    });
+  });
+
+  describe('Tasks/Backlog split simulation', () => {
+    it('splits correctly with topN', () => {
+      const tasks = Array.from({ length: 25 }, (_, i) =>
+        makeTask({
+          id: i + 1,
+          priority: 'P1',
+          createdAt: new Date(2024, 0, i + 1).toISOString(),
+        })
+      );
+      const data = makeAppData({ tasks, settings: { staleThresholdHours: 48, topN: 20, globalTimeOffset: 0 } });
+
+      const prioritized = getPrioritizedTasks(data);
+      const tasksTab = prioritized.slice(0, 20);
+      const backlogTab = prioritized.slice(20);
+
+      expect(tasksTab).toHaveLength(20);
+      expect(backlogTab).toHaveLength(5);
+    });
+
+    it('respects priority at the split boundary', () => {
+      const tasks = [
+        ...Array.from({ length: 5 }, (_, i) =>
+          makeTask({ id: i + 1, priority: 'P0', createdAt: new Date(2024, 0, i + 1).toISOString() })
+        ),
+        ...Array.from({ length: 20 }, (_, i) =>
+          makeTask({ id: i + 6, priority: 'P1', createdAt: new Date(2024, 0, i + 1).toISOString() })
+        ),
+      ];
+      const data = makeAppData({ tasks, settings: { staleThresholdHours: 48, topN: 20, globalTimeOffset: 0 } });
+
+      const prioritized = getPrioritizedTasks(data);
+      const tasksTab = prioritized.slice(0, 20);
+      const backlogTab = prioritized.slice(20);
+
+      // All 5 P0 tasks should be in the Tasks tab
+      expect(tasksTab.filter(t => t.priority === 'P0')).toHaveLength(5);
+      // First 15 P1 tasks fill the remaining spots
+      expect(tasksTab.filter(t => t.priority === 'P1')).toHaveLength(15);
+      // Last 5 P1 tasks go to backlog
+      expect(backlogTab).toHaveLength(5);
+      expect(backlogTab.every(t => t.priority === 'P1')).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array when no tasks exist', () => {
+      const data = makeAppData();
+      expect(getPrioritizedTasks(data)).toEqual([]);
+    });
+
+    it('returns empty array when all tasks are filtered out', () => {
+      const data = makeAppData({
+        tasks: [
+          makeTask({ id: 1, isArchived: true }),
+          makeTask({ id: 2, isDeleted: true }),
+          makeTask({ id: 3, completedAt: '2024-01-01T00:00:00Z' }),
+          makeTask({ id: 4, priority: null }),
+        ],
+      });
+      expect(getPrioritizedTasks(data)).toEqual([]);
+    });
+
+    it('returns single qualifying task', () => {
+      const data = makeAppData({
+        tasks: [makeTask({ id: 1, priority: 'P0' })],
+      });
+      expect(getPrioritizedTasks(data)).toHaveLength(1);
+      expect(getPrioritizedTasks(data)[0].id).toBe(1);
+    });
+  });
+});

--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeTask, makeBlocker, makeAppData, resetIdCounter } from './helpers.js';
+import type { AppData } from '../storage.js';
+
+vi.mock('../storage.js', () => ({
+  readData: vi.fn(),
+  writeData: vi.fn(),
+}));
+
+import { readData, writeData } from '../storage.js';
+import { taskRoutes } from '../routes/tasks.js';
+
+const mockedReadData = vi.mocked(readData);
+const mockedWriteData = vi.mocked(writeData);
+
+// Helper to invoke an Express route handler directly
+function findHandler(method: string, path: string) {
+  const layer = (taskRoutes as any).stack.find((s: any) =>
+    s.route?.path === path && s.route?.methods[method]
+  );
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${path}`);
+  return layer.route.stack.find((s: any) => s.method === method).handle;
+}
+
+function mockReq(overrides: Record<string, any> = {}) {
+  return { params: {}, query: {}, body: {}, ...overrides };
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.end = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetIdCounter();
+});
+
+describe('GET /tasks', () => {
+  const handler = findHandler('get', '/tasks');
+
+  it('returns tasks tab with priority then updatedAt sort', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, priority: 'P1', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-06-01T00:00:00Z' }),
+        makeTask({ id: 2, priority: 'P0', createdAt: '2024-02-01T00:00:00Z', updatedAt: '2024-03-01T00:00:00Z' }),
+        makeTask({ id: 3, priority: 'P1', createdAt: '2024-03-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'tasks' } }), res);
+
+    const tasks = res.json.mock.calls[0][0];
+    // P0 first, then P1s sorted by updatedAt ascending
+    expect(tasks.map((t: any) => t.id)).toEqual([2, 3, 1]);
+  });
+
+  it('slices tasks to topN', () => {
+    const tasks = Array.from({ length: 5 }, (_, i) =>
+      makeTask({ id: i + 1, priority: 'P1', createdAt: new Date(2024, 0, i + 1).toISOString() })
+    );
+    const data = makeAppData({
+      tasks,
+      settings: { staleThresholdHours: 48, topN: 3, globalTimeOffset: 0 },
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'tasks' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toHaveLength(3);
+  });
+
+  it('returns backlog as overflow beyond topN', () => {
+    const tasks = Array.from({ length: 5 }, (_, i) =>
+      makeTask({ id: i + 1, priority: 'P1', createdAt: new Date(2024, 0, i + 1).toISOString() })
+    );
+    const data = makeAppData({
+      tasks,
+      settings: { staleThresholdHours: 48, topN: 3, globalTimeOffset: 0 },
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'backlog' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('returns ideas (null priority tasks)', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, priority: null }),
+        makeTask({ id: 2, priority: 'P1' }),
+        makeTask({ id: 3, priority: null }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'ideas' } }), res);
+
+    const ideas = res.json.mock.calls[0][0];
+    expect(ideas).toHaveLength(2);
+    expect(ideas.every((t: any) => t.priority === null)).toBe(true);
+  });
+
+  it('returns blocked tasks', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, priority: 'P1' }),
+        makeTask({ id: 2, priority: 'P1' }),
+      ],
+      blockers: [makeBlocker({ taskId: 1, resolved: false })],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'blocked' } }), res);
+
+    const blocked = res.json.mock.calls[0][0];
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0].id).toBe(1);
+  });
+
+  it('returns completed tasks sorted newest first', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, completedAt: '2024-01-01T00:00:00Z' }),
+        makeTask({ id: 2, completedAt: '2024-06-01T00:00:00Z' }),
+        makeTask({ id: 3, completedAt: null }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'completed' } }), res);
+
+    const completed = res.json.mock.calls[0][0];
+    expect(completed).toHaveLength(2);
+    expect(completed[0].id).toBe(2); // newest first
+  });
+
+  it('returns archived tasks', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, isArchived: true }),
+        makeTask({ id: 2, isArchived: false }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'archive' } }), res);
+
+    const archived = res.json.mock.calls[0][0];
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe(1);
+  });
+
+  it('returns trash (deleted tasks)', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, isDeleted: true }),
+        makeTask({ id: 2, isDeleted: false }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'trash' } }), res);
+
+    const trash = res.json.mock.calls[0][0];
+    expect(trash).toHaveLength(1);
+    expect(trash[0].id).toBe(1);
+  });
+
+  it('calls writeData when autoUnblock resolves blockers', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 })],
+      blockers: [makeBlocker({ taskId: 1, blockedUntilDate: '2020-01-01T00:00:00Z', resolved: false })],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'tasks' } }), res);
+
+    expect(mockedWriteData).toHaveBeenCalled();
+  });
+
+  it('does not call writeData when no blockers are resolved', () => {
+    const data = makeAppData({
+      tasks: [makeTask({ id: 1 })],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'tasks' } }), res);
+
+    expect(mockedWriteData).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array for unknown tab', () => {
+    const data = makeAppData({ tasks: [makeTask({ id: 1 })] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'unknown' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toEqual([]);
+  });
+
+  it('excludes deleted tasks from ideas tab', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, priority: null, isDeleted: true }),
+        makeTask({ id: 2, priority: null, isDeleted: false }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'ideas' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toHaveLength(1);
+    expect(res.json.mock.calls[0][0][0].id).toBe(2);
+  });
+
+  it('excludes deleted tasks from archive tab', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, isArchived: true, isDeleted: true }),
+        makeTask({ id: 2, isArchived: true, isDeleted: false }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'archive' } }), res);
+
+    expect(res.json.mock.calls[0][0]).toHaveLength(1);
+    expect(res.json.mock.calls[0][0][0].id).toBe(2);
+  });
+});
+
+describe('POST /tasks', () => {
+  const handler = findHandler('post', '/tasks');
+
+  it('creates a task with correct defaults', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: 'New task' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    const task = res.json.mock.calls[0][0];
+    expect(task.title).toBe('New task');
+    expect(task.status).toBe('');
+    expect(task.priority).toBe(null);
+    expect(task.completedAt).toBe(null);
+    expect(task.isArchived).toBe(false);
+    expect(task.isDeleted).toBe(false);
+  });
+
+  it('trims the title', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: '  spaces  ' } }), res);
+
+    expect(res.json.mock.calls[0][0].title).toBe('spaces');
+  });
+
+  it('returns 400 when title is missing', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when title is not a string', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: 123 } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('increments nextTaskId', () => {
+    const data = makeAppData({ nextTaskId: 50 });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: 'Test' } }), res);
+
+    expect(res.json.mock.calls[0][0].id).toBe(50);
+    expect(data.nextTaskId).toBe(51);
+  });
+
+  it('calls writeData', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: 'Test' } }), res);
+
+    expect(mockedWriteData).toHaveBeenCalledWith(data);
+  });
+
+  it('accepts priority and status', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ body: { title: 'Test', priority: 'P0', status: 'In progress' } }), res);
+
+    const task = res.json.mock.calls[0][0];
+    expect(task.priority).toBe('P0');
+    expect(task.status).toBe('In progress');
+  });
+});
+
+describe('PUT /tasks/:id', () => {
+  const handler = findHandler('put', '/tasks/:id');
+
+  it('updates title and trims it', () => {
+    const task = makeTask({ id: 1, title: 'Old' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { title: '  New  ' } }), res);
+
+    expect(res.json.mock.calls[0][0].title).toBe('New');
+  });
+
+  it('updates only provided fields', () => {
+    const task = makeTask({ id: 1, title: 'Original', status: 'Active', priority: 'P1' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { title: 'Changed' } }), res);
+
+    const updated = res.json.mock.calls[0][0];
+    expect(updated.title).toBe('Changed');
+    expect(updated.status).toBe('Active');
+    expect(updated.priority).toBe('P1');
+  });
+
+  it('sets priority to null when falsy value provided', () => {
+    const task = makeTask({ id: 1, priority: 'P0' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { priority: '' } }), res);
+
+    expect(res.json.mock.calls[0][0].priority).toBe(null);
+  });
+
+  it('returns 404 for nonexistent task', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' }, body: { title: 'Test' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('updates isArchived', () => {
+    const task = makeTask({ id: 1, isArchived: false });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { isArchived: true } }), res);
+
+    expect(res.json.mock.calls[0][0].isArchived).toBe(true);
+  });
+
+  it('updates isDeleted', () => {
+    const task = makeTask({ id: 1, isDeleted: false });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { isDeleted: true } }), res);
+
+    expect(res.json.mock.calls[0][0].isDeleted).toBe(true);
+  });
+});
+
+describe('POST /tasks/:id/complete', () => {
+  const handler = findHandler('post', '/tasks/:id/complete');
+
+  it('sets completedAt and updatedAt', () => {
+    const task = makeTask({ id: 1, completedAt: null });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    const completed = res.json.mock.calls[0][0];
+    expect(completed.completedAt).not.toBe(null);
+    expect(completed.updatedAt).toBe(completed.completedAt);
+  });
+
+  it('resolves dependent blockers', () => {
+    const task = makeTask({ id: 1 });
+    const blocker = makeBlocker({ taskId: 2, blockedByTaskId: 1, resolved: false });
+    const unrelatedBlocker = makeBlocker({ taskId: 3, blockedByTaskId: 5, resolved: false });
+    const data = makeAppData({ tasks: [task], blockers: [blocker, unrelatedBlocker] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(blocker.resolved).toBe(true);
+    expect(unrelatedBlocker.resolved).toBe(false);
+  });
+
+  it('returns 404 for nonexistent task', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe('POST /tasks/:id/uncomplete', () => {
+  const handler = findHandler('post', '/tasks/:id/uncomplete');
+
+  it('clears completedAt', () => {
+    const task = makeTask({ id: 1, completedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(res.json.mock.calls[0][0].completedAt).toBe(null);
+  });
+
+  it('updates updatedAt', () => {
+    const task = makeTask({ id: 1, completedAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(res.json.mock.calls[0][0].updatedAt).not.toBe('2024-01-01T00:00:00Z');
+  });
+
+  it('returns 404 for nonexistent task', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});
+
+describe('DELETE /tasks/:id', () => {
+  const handler = findHandler('delete', '/tasks/:id');
+
+  it('soft-deletes by default', () => {
+    const task = makeTask({ id: 1, isDeleted: false });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, query: {} }), res);
+
+    expect(res.json.mock.calls[0][0].isDeleted).toBe(true);
+    expect(data.tasks).toHaveLength(1); // still in the array
+  });
+
+  it('resolves dependent blockers on soft-delete', () => {
+    const task = makeTask({ id: 1 });
+    const blocker = makeBlocker({ taskId: 2, blockedByTaskId: 1, resolved: false });
+    const data = makeAppData({ tasks: [task], blockers: [blocker] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, query: {} }), res);
+
+    expect(blocker.resolved).toBe(true);
+  });
+
+  it('hard-deletes with permanent=true', () => {
+    const task = makeTask({ id: 1 });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, query: { permanent: 'true' } }), res);
+
+    expect(data.tasks).toHaveLength(0);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('removes associated blockers on hard delete', () => {
+    const task = makeTask({ id: 1 });
+    const blockerFor = makeBlocker({ id: 10, taskId: 1 });
+    const blockerBy = makeBlocker({ id: 11, taskId: 2, blockedByTaskId: 1 });
+    const unrelated = makeBlocker({ id: 12, taskId: 3, blockedByTaskId: 4 });
+    const data = makeAppData({ tasks: [task], blockers: [blockerFor, blockerBy, unrelated] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, query: { permanent: 'true' } }), res);
+
+    expect(data.blockers).toHaveLength(1);
+    expect(data.blockers[0].id).toBe(12);
+  });
+
+  it('returns 404 for nonexistent task on soft delete', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' }, query: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 404 for nonexistent task on hard delete', () => {
+    const data = makeAppData();
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '999' }, query: { permanent: 'true' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/server/task-logic.ts
+++ b/server/task-logic.ts
@@ -1,0 +1,46 @@
+import type { AppData, Task } from './storage.js';
+
+export const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2 };
+
+export function autoUnblock(data: AppData): boolean {
+  const now = new Date();
+  let changed = false;
+
+  for (const blocker of data.blockers) {
+    if (blocker.resolved) continue;
+
+    // Date-based auto-unblock
+    if (blocker.blockedUntilDate && new Date(blocker.blockedUntilDate) <= now) {
+      blocker.resolved = true;
+      changed = true;
+    }
+
+    // Task-based auto-unblock
+    if (blocker.blockedByTaskId != null) {
+      const blockingTask = data.tasks.find(t => t.id === blocker.blockedByTaskId);
+      if (blockingTask && blockingTask.completedAt != null) {
+        blocker.resolved = true;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+export function hasUnresolvedBlockers(taskId: number, data: AppData): boolean {
+  return data.blockers.some(b => b.taskId === taskId && !b.resolved);
+}
+
+export function getPrioritizedTasks(data: AppData): Task[] {
+  return data.tasks
+    .filter(t => t.priority != null && !t.isArchived && !t.isDeleted && t.completedAt == null && !hasUnresolvedBlockers(t.id, data))
+    .sort((a, b) => {
+      const pa = PRIORITY_ORDER[a.priority!] ?? 99;
+      const pb = PRIORITY_ORDER[b.priority!] ?? 99;
+      if (pa !== pb) return pa - pb;
+      // Stable tiebreaker: createdAt doesn't change on edits,
+      // so updating a task's status won't shuffle it between Tasks/Backlog
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -11,5 +11,6 @@
     "declaration": false,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["server"]
+  "include": ["server"],
+  "exclude": ["server/__tests__"]
 }

--- a/vitest.config.server.ts
+++ b/vitest.config.server.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['server/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- **Test infrastructure**: Vitest with server-specific config, npm scripts (`test` and `test:watch`)
- **Refactor for testability**: Extract `autoUnblock`, `hasUnresolvedBlockers`, `getPrioritizedTasks`, and `PRIORITY_ORDER` into `server/task-logic.ts` as pure exported functions
- **83 tests across 4 files**: task-logic (28), task-routes (38), blocker-routes (11), settings-routes (6)
- **Stable Tasks/Backlog split**: Use `createdAt` instead of `updatedAt` as tiebreaker so editing a task status no longer shuffles it between tabs

## Test plan
- [ ] Run `npm test` -- all 83 tests pass
- [ ] Run `npx tsc -p tsconfig.server.json --noEmit` -- server compiles cleanly
- [ ] Run `npm run dev` -- app still works as before