### PR TITLE
Add release update checks with settings integration

### DIFF
--- a/server/__tests__/update-routes.test.ts
+++ b/server/__tests__/update-routes.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { updateRoutes } from '../routes/update.js';
+
+function findHandler(method: string, routePath: string) {
+  const layer = (updateRoutes as any).stack.find((s: any) =>
+    s.route?.path === routePath && s.route?.methods[method]
+  );
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack.find((s: any) => s.method === method).handle;
+}
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return { params: {}, query: {}, body: {}, ...overrides };
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.send = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+const currentVersion = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf-8')
+) as { version: string };
+
+describe('GET /update-check', () => {
+  const handler = findHandler('get', '/update-check');
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...originalEnv };
+  });
+
+  it('returns hasUpdate=true when latest release is newer', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        tag_name: 'v999.0.0',
+        html_url: 'https://github.com/svakili/stradl/releases/tag/v999.0.0',
+        published_at: '2026-02-01T00:00:00.000Z',
+        name: 'v999.0.0',
+      }),
+    } as any);
+
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.hasUpdate).toBe(true);
+    expect(payload.latestVersion).toBe('999.0.0');
+  });
+
+  it('returns hasUpdate=false when latest equals current version', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        tag_name: `v${currentVersion.version}`,
+        html_url: `https://github.com/svakili/stradl/releases/tag/v${currentVersion.version}`,
+        published_at: '2026-02-01T00:00:00.000Z',
+        name: `v${currentVersion.version}`,
+      }),
+    } as any);
+
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.hasUpdate).toBe(false);
+    expect(payload.currentVersion).toBe(currentVersion.version);
+    expect(payload.latestVersion).toBe(currentVersion.version);
+  });
+
+  it('handles v-prefixed versions correctly', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        tag_name: 'v1.2.3',
+        html_url: 'https://github.com/svakili/stradl/releases/tag/v1.2.3',
+        published_at: '2026-02-01T00:00:00.000Z',
+        name: 'v1.2.3',
+      }),
+    } as any);
+
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.latestVersion).toBe('1.2.3');
+  });
+
+  it('returns non-2xx when upstream GitHub API fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: vi.fn().mockResolvedValue('service unavailable'),
+    } as any);
+
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.send).toHaveBeenCalledWith('Failed to check updates (GitHub 503).');
+  });
+
+  it('includes releaseUrl, publishedAt, and checkedAt in successful response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        tag_name: 'v9.9.9',
+        html_url: 'https://github.com/svakili/stradl/releases/tag/v9.9.9',
+        published_at: '2026-02-10T12:00:00.000Z',
+        name: 'v9.9.9',
+      }),
+    } as any);
+
+    const res = mockRes();
+    await handler(mockReq(), res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.releaseUrl).toBe('https://github.com/svakili/stradl/releases/tag/v9.9.9');
+    expect(payload.publishedAt).toBe('2026-02-10T12:00:00.000Z');
+    expect(typeof payload.checkedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(payload.checkedAt))).toBe(false);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { taskRoutes } from './routes/tasks.js';
 import { blockerRoutes } from './routes/blockers.js';
 import { settingsRoutes } from './routes/settings.js';
+import { updateRoutes } from './routes/update.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
@@ -15,6 +16,7 @@ app.use(express.json());
 app.use('/api', taskRoutes);
 app.use('/api', blockerRoutes);
 app.use('/api', settingsRoutes);
+app.use('/api', updateRoutes);
 
 // Serve static files in production (Vite build output is at project root /dist)
 // When running compiled JS from server/dist/, go up two levels to project root

--- a/server/routes/update.ts
+++ b/server/routes/update.ts
@@ -1,0 +1,141 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Router } from 'express';
+
+interface GitHubRelease {
+  tag_name: string;
+  html_url: string;
+  published_at: string;
+  name?: string;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function findProjectRoot(): string {
+  const candidates = [
+    path.resolve(__dirname, '../../..'),
+    path.resolve(__dirname, '../..'),
+  ];
+
+  const resolved = candidates.find((candidate) =>
+    fs.existsSync(path.join(candidate, 'package.json'))
+  );
+
+  if (!resolved) {
+    throw new Error('Project root not found.');
+  }
+
+  return resolved;
+}
+
+function normalizeVersion(value: string): string {
+  return value.trim().replace(/^v/i, '');
+}
+
+function parseSemver(value: string): [number, number, number] {
+  const normalized = normalizeVersion(value);
+  const match = normalized.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error('Invalid version format.');
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isVersionNewer(latest: string, current: string): boolean {
+  const [latestMajor, latestMinor, latestPatch] = parseSemver(latest);
+  const [currentMajor, currentMinor, currentPatch] = parseSemver(current);
+
+  if (latestMajor !== currentMajor) return latestMajor > currentMajor;
+  if (latestMinor !== currentMinor) return latestMinor > currentMinor;
+  return latestPatch > currentPatch;
+}
+
+function readCurrentVersion(): string {
+  const packagePath = path.join(findProjectRoot(), 'package.json');
+  const raw = fs.readFileSync(packagePath, 'utf-8');
+  const parsed = JSON.parse(raw) as { version?: string };
+
+  if (!parsed.version || typeof parsed.version !== 'string') {
+    throw new Error('App version missing.');
+  }
+
+  return normalizeVersion(parsed.version);
+}
+
+export const updateRoutes = Router();
+
+updateRoutes.get('/update-check', async (_req, res) => {
+  const checkedAt = new Date().toISOString();
+
+  let currentVersion: string;
+  try {
+    currentVersion = readCurrentVersion();
+  } catch {
+    res.status(500).send('Failed to read local app version.');
+    return;
+  }
+
+  const owner = process.env.STRADL_UPDATE_OWNER || 'svakili';
+  const repo = process.env.STRADL_UPDATE_REPO || 'stradl';
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'stradl-update-checker',
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  let releaseRes: Response;
+  try {
+    releaseRes = await fetch(url, { headers });
+  } catch {
+    res.status(502).send('Failed to reach GitHub release API.');
+    return;
+  }
+
+  if (!releaseRes.ok) {
+    res.status(502).send(`Failed to check updates (GitHub ${releaseRes.status}).`);
+    return;
+  }
+
+  let release: Partial<GitHubRelease>;
+  try {
+    release = (await releaseRes.json()) as Partial<GitHubRelease>;
+  } catch {
+    res.status(502).send('Failed to parse GitHub release response.');
+    return;
+  }
+
+  if (
+    typeof release.tag_name !== 'string' ||
+    typeof release.html_url !== 'string' ||
+    typeof release.published_at !== 'string'
+  ) {
+    res.status(502).send('GitHub release response missing required fields.');
+    return;
+  }
+
+  const latestVersion = normalizeVersion(release.tag_name);
+
+  let hasUpdate: boolean;
+  try {
+    hasUpdate = isVersionNewer(latestVersion, currentVersion);
+  } catch {
+    res.status(502).send('GitHub release version format is invalid.');
+    return;
+  }
+
+  res.json({
+    currentVersion,
+    latestVersion,
+    hasUpdate,
+    releaseUrl: release.html_url,
+    releaseName: (release.name && release.name.trim()) || `v${latestVersion}`,
+    publishedAt: release.published_at,
+    checkedAt,
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import type { Task, Blocker, Settings, TabName } from './types';
+import type { Task, Blocker, Settings, TabName, UpdateCheckResult } from './types';
 
 const BASE = '/api';
 
@@ -55,3 +55,7 @@ export const fetchSettings = () =>
 
 export const updateSettings = (data: Partial<Settings>) =>
   request<Settings>('/settings', { method: 'PUT', body: JSON.stringify(data) });
+
+// Updates
+export const checkForUpdates = () =>
+  request<UpdateCheckResult>('/update-check');

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -3,6 +3,8 @@ import TaskRow from './TaskRow';
 
 interface Props {
   tasks: Task[];
+  searchQuery: string;
+  hasActiveSearch: boolean;
   settings: Settings;
   allTasks: Task[];
   blockers: Record<number, Blocker[]>;
@@ -19,12 +21,13 @@ interface Props {
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
   onPermanentDelete: (id: number) => Promise<void>;
+  onClearSearch: () => void;
 }
 
 export default function TaskTable({
-  tasks, settings, allTasks, blockers, pendingActionByTaskId, activeTab, loading, recentlyUpdatedIds,
+  tasks, searchQuery, hasActiveSearch, settings, allTasks, blockers, pendingActionByTaskId, activeTab, loading, recentlyUpdatedIds,
   onTabChange, onUpdate, onComplete, onUncomplete, onDelete,
-  onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete,
+  onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete, onClearSearch,
 }: Props) {
   const showStaleness = activeTab === 'tasks';
 
@@ -60,13 +63,26 @@ export default function TaskTable({
     trash: {
       title: 'Trash is empty',
       description: 'Nothing deleted yet.',
-      ctaLabel: 'Nothing deleted yet',
-      ctaTab: 'tasks',
     },
   };
 
   if (loading) return <div className="loading" id={`tab-panel-${activeTab}`} role="tabpanel">Loading...</div>;
   if (tasks.length === 0) {
+    if (hasActiveSearch) {
+      const query = searchQuery.trim();
+      return (
+        <div className="empty-state search-empty-state" id={`tab-panel-${activeTab}`} role="tabpanel">
+          <h2 className="empty-state-title">No matches found</h2>
+          <p className="empty-state-description">
+            No tasks match <span className="search-empty-state-query">"{query}"</span> in this tab.
+          </p>
+          <button className="btn empty-state-action" onClick={onClearSearch}>
+            Clear search
+          </button>
+        </div>
+      );
+    }
+
     const state = EMPTY_STATES[activeTab];
     const ctaTab = state.ctaTab;
     return (

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,86 @@
+import { useCallback, useState } from 'react';
+import type { UpdateCheckResult } from '../types';
+import * as api from '../api';
+
+const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const LAST_CHECKED_KEY = 'stradl-update-last-checked-at';
+const LAST_RESULT_KEY = 'stradl-update-last-result';
+export const LAST_NOTIFIED_VERSION_KEY = 'stradl-update-last-notified-version';
+
+function getStoredString(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredString(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage errors in private browsing / restricted contexts.
+  }
+}
+
+function getStoredResult(): UpdateCheckResult | null {
+  const raw = getStoredString(LAST_RESULT_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as UpdateCheckResult;
+  } catch {
+    return null;
+  }
+}
+
+export function useUpdateCheck() {
+  const [isChecking, setIsChecking] = useState(false);
+  const [lastResult, setLastResult] = useState<UpdateCheckResult | null>(() => getStoredResult());
+  const [lastCheckedAt, setLastCheckedAt] = useState<string | null>(() => getStoredString(LAST_CHECKED_KEY));
+  const [error, setError] = useState<string | null>(null);
+
+  const checkNow = useCallback(async ({ manual }: { manual: boolean }) => {
+    if (isChecking) return lastResult;
+
+    setIsChecking(true);
+    setError(null);
+
+    try {
+      const result = await api.checkForUpdates();
+      setLastResult(result);
+      setLastCheckedAt(result.checkedAt);
+      setStoredString(LAST_CHECKED_KEY, result.checkedAt);
+      setStoredString(LAST_RESULT_KEY, JSON.stringify(result));
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to check for updates.';
+      if (manual) {
+        setError(message);
+        throw new Error(message);
+      }
+      return null;
+    } finally {
+      setIsChecking(false);
+    }
+  }, [isChecking, lastResult]);
+
+  const maybeAutoCheck = useCallback(async () => {
+    const storedCheckedAt = getStoredString(LAST_CHECKED_KEY);
+    if (storedCheckedAt) {
+      const parsed = Date.parse(storedCheckedAt);
+      if (!Number.isNaN(parsed) && Date.now() - parsed < AUTO_CHECK_INTERVAL_MS) {
+        return null;
+      }
+    }
+    return checkNow({ manual: false });
+  }, [checkNow]);
+
+  return {
+    isChecking,
+    lastResult,
+    lastCheckedAt,
+    error,
+    checkNow,
+    maybeAutoCheck,
+  };
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -572,6 +572,25 @@ textarea:focus-visible,
   margin-top: 0.5rem;
 }
 
+.settings-updates-section {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.settings-updates-title {
+  font-size: 0.8125rem;
+  margin-bottom: 0.25rem;
+}
+
+.settings-update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
 /* Dark Mode Toggle */
 .theme-toggle {
   border: none;
@@ -608,6 +627,11 @@ textarea:focus-visible,
 
 .empty-state-action {
   margin: 0 auto;
+}
+
+.search-empty-state-query {
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 /* Toast Container & Items */
@@ -648,6 +672,10 @@ textarea:focus-visible,
 
 .toast-error {
   border-color: var(--red-border);
+}
+
+.toast-info {
+  border-color: var(--blue-100);
 }
 
 .toast-actions {
@@ -829,6 +857,11 @@ textarea:focus-visible,
     left: 0;
     right: 0;
     min-width: 0;
+  }
+
+  .settings-update-actions .btn {
+    width: 100%;
+    text-align: center;
   }
 
   .toast-container {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,4 +24,14 @@ export interface Settings {
   globalTimeOffset: number;
 }
 
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestVersion: string;
+  hasUpdate: boolean;
+  releaseUrl: string;
+  releaseName: string;
+  publishedAt: string;
+  checkedAt: string;
+}
+
 export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive' | 'trash';


### PR DESCRIPTION
## Summary
- add server-side /api/update-check endpoint that proxies GitHub Releases latest and compares semver
- add frontend update check API/types/hook with daily throttling and localStorage dedupe
- add Settings UI for manual update checks, status display, and release notes link
- add update route tests and wire route into server

## Validation
- npm run build
- npm test