### PR TITLE
Add one-command release scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ npm start
 
 Builds the frontend and compiles the server TypeScript, then serves everything from http://localhost:3001.
 
+## Releasing
+
+This project includes one-command release scripts that:
+- ensure you are on a clean `main` branch
+- pull latest `origin/main`
+- bump version + create tag via `npm version`
+- push commit and tag
+- create a GitHub release with generated notes
+
+Use one of:
+
+```bash
+npm run release:patch
+npm run release:minor
+npm run release:major
+```
+
+Notes:
+- Requires `gh` authenticated (`gh auth status`)
+- Release tags are `v<version>` and match `package.json` version
+
 ## Auto-Start on Login (macOS)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "install-service": "node scripts/install-service.js",
     "uninstall-service": "node scripts/uninstall-service.js",
+    "release:patch": "node scripts/release.js patch",
+    "release:minor": "node scripts/release.js minor",
+    "release:major": "node scripts/release.js major",
     "test": "vitest run --config vitest.config.server.ts",
     "test:watch": "vitest --config vitest.config.server.ts"
   },

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const VALID_BUMPS = new Set(['patch', 'minor', 'major']);
+
+function fail(message) {
+  console.error(`\nRelease aborted: ${message}`);
+  process.exit(1);
+}
+
+function run(command) {
+  console.log(`\n$ ${command}`);
+  execSync(command, { stdio: 'inherit' });
+}
+
+function runCapture(command) {
+  return execSync(command, { encoding: 'utf-8' }).trim();
+}
+
+function ensureTool(tool) {
+  try {
+    runCapture(`${tool} --version`);
+  } catch {
+    fail(`Required tool "${tool}" is not available on PATH.`);
+  }
+}
+
+const bump = process.argv[2];
+if (!VALID_BUMPS.has(bump)) {
+  console.error('Usage: node scripts/release.js <patch|minor|major>');
+  process.exit(1);
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const packageJsonPath = path.join(projectRoot, 'package.json');
+
+process.chdir(projectRoot);
+
+ensureTool('git');
+ensureTool('gh');
+ensureTool('npm');
+
+const branch = runCapture('git rev-parse --abbrev-ref HEAD');
+if (branch !== 'main') {
+  fail(`You must release from "main" (current: "${branch}").`);
+}
+
+const dirty = runCapture('git status --porcelain');
+if (dirty) {
+  fail('Working tree is not clean. Commit or stash changes first.');
+}
+
+run('git fetch origin main');
+run('git pull --ff-only origin main');
+run(`npm version ${bump}`);
+
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const version = pkg.version;
+const tag = `v${version}`;
+
+run('git push origin main --follow-tags');
+run(`gh release create ${tag} --generate-notes`);
+
+console.log(`\nRelease complete: ${tag}`);


### PR DESCRIPTION
## Summary
- add scripts/release.js to automate patch/minor/major releases
- add npm scripts release:patch, release:minor, release:major
- document release workflow in README

## Validation
- npm run build
- npm test