### PR TITLE
Replace persistent vacation offset with one-time inactivity popup

### DIFF
--- a/server/__tests__/helpers.ts
+++ b/server/__tests__/helpers.ts
@@ -38,7 +38,9 @@ export function makeAppData(overrides: Partial<AppData> = {}): AppData {
     settings: {
       staleThresholdHours: 48,
       topN: 20,
-      globalTimeOffset: 0,
+      oneTimeOffsetHours: 0,
+      oneTimeOffsetExpiresAt: null,
+      vacationPromptLastShownForUpdatedAt: null,
     },
     nextTaskId: 100,
     nextBlockerId: 100,

--- a/server/__tests__/staleness.test.ts
+++ b/server/__tests__/staleness.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isStale } from '../../src/utils/staleness.js';
+import type { Settings } from '../../src/types.js';
+
+function withNow(isoTime: string, fn: () => void) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(isoTime));
+  try {
+    fn();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+const baseSettings: Settings = {
+  staleThresholdHours: 24,
+  topN: 20,
+  oneTimeOffsetHours: 0,
+  oneTimeOffsetExpiresAt: null,
+  vacationPromptLastShownForUpdatedAt: null,
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isStale', () => {
+  it('delays stale status when one-time offset is active', () => {
+    withNow('2026-02-23T12:00:00.000Z', () => {
+      const settings: Settings = {
+        ...baseSettings,
+        oneTimeOffsetHours: 24,
+        oneTimeOffsetExpiresAt: '2026-02-23T23:59:59.999Z',
+      };
+      // 30h elapsed should not be stale if threshold is 24h + 24h offset.
+      const stale = isStale('2026-02-22T06:00:00.000Z', settings);
+      expect(stale).toBe(false);
+    });
+  });
+
+  it('does not apply one-time offset after expiry', () => {
+    withNow('2026-02-24T12:00:00.000Z', () => {
+      const settings: Settings = {
+        ...baseSettings,
+        oneTimeOffsetHours: 24,
+        oneTimeOffsetExpiresAt: '2026-02-23T23:59:59.999Z',
+      };
+      // 30h elapsed should be stale once offset has expired.
+      const stale = isStale('2026-02-23T06:00:00.000Z', settings);
+      expect(stale).toBe(true);
+    });
+  });
+
+  it('uses stale threshold only when no one-time offset exists', () => {
+    withNow('2026-02-23T12:00:00.000Z', () => {
+      const stale = isStale('2026-02-22T11:00:00.000Z', baseSettings);
+      expect(stale).toBe(true);
+    });
+  });
+});

--- a/server/__tests__/task-logic.test.ts
+++ b/server/__tests__/task-logic.test.ts
@@ -243,7 +243,16 @@ describe('getPrioritizedTasks', () => {
           createdAt: new Date(2024, 0, i + 1).toISOString(),
         })
       );
-      const data = makeAppData({ tasks, settings: { staleThresholdHours: 48, topN: 20, globalTimeOffset: 0 } });
+      const data = makeAppData({
+        tasks,
+        settings: {
+          staleThresholdHours: 48,
+          topN: 20,
+          oneTimeOffsetHours: 0,
+          oneTimeOffsetExpiresAt: null,
+          vacationPromptLastShownForUpdatedAt: null,
+        },
+      });
 
       const prioritized = getPrioritizedTasks(data);
       const tasksTab = prioritized.slice(0, 20);
@@ -262,7 +271,16 @@ describe('getPrioritizedTasks', () => {
           makeTask({ id: i + 6, priority: 'P1', createdAt: new Date(2024, 0, i + 1).toISOString() })
         ),
       ];
-      const data = makeAppData({ tasks, settings: { staleThresholdHours: 48, topN: 20, globalTimeOffset: 0 } });
+      const data = makeAppData({
+        tasks,
+        settings: {
+          staleThresholdHours: 48,
+          topN: 20,
+          oneTimeOffsetHours: 0,
+          oneTimeOffsetExpiresAt: null,
+          vacationPromptLastShownForUpdatedAt: null,
+        },
+      });
 
       const prioritized = getPrioritizedTasks(data);
       const tasksTab = prioritized.slice(0, 20);

--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -66,7 +66,13 @@ describe('GET /tasks', () => {
     );
     const data = makeAppData({
       tasks,
-      settings: { staleThresholdHours: 48, topN: 3, globalTimeOffset: 0 },
+      settings: {
+        staleThresholdHours: 48,
+        topN: 3,
+        oneTimeOffsetHours: 0,
+        oneTimeOffsetExpiresAt: null,
+        vacationPromptLastShownForUpdatedAt: null,
+      },
     });
     mockedReadData.mockReturnValue(data);
     const res = mockRes();
@@ -82,7 +88,13 @@ describe('GET /tasks', () => {
     );
     const data = makeAppData({
       tasks,
-      settings: { staleThresholdHours: 48, topN: 3, globalTimeOffset: 0 },
+      settings: {
+        staleThresholdHours: 48,
+        topN: 3,
+        oneTimeOffsetHours: 0,
+        oneTimeOffsetExpiresAt: null,
+        vacationPromptLastShownForUpdatedAt: null,
+      },
     });
     mockedReadData.mockReturnValue(data);
     const res = mockRes();

--- a/server/__tests__/vacation-nudge.test.ts
+++ b/server/__tests__/vacation-nudge.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { getVacationNudgeRecommendation } from '../../src/utils/vacationNudge.js';
+import type { Settings, Task } from '../../src/types.js';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 1,
+    title: 'Task',
+    status: 'Open',
+    priority: null,
+    createdAt: '2026-02-20T00:00:00.000Z',
+    updatedAt: '2026-02-20T09:00:00.000Z',
+    completedAt: null,
+    isArchived: false,
+    isDeleted: false,
+    ...overrides,
+  };
+}
+
+const baseSettings: Settings = {
+  staleThresholdHours: 24,
+  topN: 20,
+  oneTimeOffsetHours: 0,
+  oneTimeOffsetExpiresAt: null,
+  vacationPromptLastShownForUpdatedAt: null,
+};
+
+describe('getVacationNudgeRecommendation', () => {
+  it('returns recommendation when most recent active update is older than 24 hours', () => {
+    const recommendation = getVacationNudgeRecommendation({
+      tasks: [makeTask({ updatedAt: '2026-02-20T09:00:00.000Z' })],
+      settings: baseSettings,
+      nowMs: Date.parse('2026-02-23T10:00:00.000Z'),
+    });
+
+    expect(recommendation).not.toBeNull();
+    expect(recommendation?.suggestedDays).toBe(3);
+    expect(recommendation?.mostRecentActiveUpdatedAt).toBe('2026-02-20T09:00:00.000Z');
+  });
+
+  it('suppresses popup for the same inactivity streak once already shown', () => {
+    const mostRecentUpdatedAt = '2026-02-20T09:00:00.000Z';
+
+    const recommendation = getVacationNudgeRecommendation({
+      tasks: [makeTask({ updatedAt: mostRecentUpdatedAt })],
+      settings: {
+        ...baseSettings,
+        vacationPromptLastShownForUpdatedAt: mostRecentUpdatedAt,
+      },
+      nowMs: Date.parse('2026-02-23T10:00:00.000Z'),
+    });
+
+    expect(recommendation).toBeNull();
+  });
+});

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -12,11 +12,19 @@ settingsRoutes.get('/settings', (_req, res) => {
 // PUT /api/settings
 settingsRoutes.put('/settings', (req, res) => {
   const data = readData();
-  const { staleThresholdHours, topN, globalTimeOffset } = req.body;
+  const {
+    staleThresholdHours,
+    topN,
+    oneTimeOffsetHours,
+    oneTimeOffsetExpiresAt,
+    vacationPromptLastShownForUpdatedAt,
+  } = req.body;
 
   if (staleThresholdHours !== undefined) data.settings.staleThresholdHours = staleThresholdHours;
   if (topN !== undefined) data.settings.topN = topN;
-  if (globalTimeOffset !== undefined) data.settings.globalTimeOffset = globalTimeOffset;
+  if (oneTimeOffsetHours !== undefined) data.settings.oneTimeOffsetHours = oneTimeOffsetHours;
+  if (oneTimeOffsetExpiresAt !== undefined) data.settings.oneTimeOffsetExpiresAt = oneTimeOffsetExpiresAt;
+  if (vacationPromptLastShownForUpdatedAt !== undefined) data.settings.vacationPromptLastShownForUpdatedAt = vacationPromptLastShownForUpdatedAt;
 
   writeData(data);
   res.json(data.settings);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -29,7 +29,9 @@ export interface Blocker {
 export interface Settings {
   staleThresholdHours: number;
   topN: number;
-  globalTimeOffset: number;
+  oneTimeOffsetHours: number;
+  oneTimeOffsetExpiresAt: string | null;
+  vacationPromptLastShownForUpdatedAt: string | null;
 }
 
 export interface AppData {
@@ -47,7 +49,9 @@ function defaultData(): AppData {
     settings: {
       staleThresholdHours: 48,
       topN: 20,
-      globalTimeOffset: 0,
+      oneTimeOffsetHours: 0,
+      oneTimeOffsetExpiresAt: null,
+      vacationPromptLastShownForUpdatedAt: null,
     },
     nextTaskId: 1,
     nextBlockerId: 1,
@@ -64,7 +68,29 @@ export function readData(): AppData {
     return data;
   }
   const raw = fs.readFileSync(DATA_FILE, 'utf-8');
-  return JSON.parse(raw) as AppData;
+  const parsed = JSON.parse(raw) as AppData;
+  const defaults = defaultData().settings;
+  const incoming = parsed.settings as Partial<Settings> | undefined;
+
+  parsed.settings = {
+    staleThresholdHours: typeof incoming?.staleThresholdHours === 'number'
+      ? incoming.staleThresholdHours
+      : defaults.staleThresholdHours,
+    topN: typeof incoming?.topN === 'number'
+      ? incoming.topN
+      : defaults.topN,
+    oneTimeOffsetHours: typeof incoming?.oneTimeOffsetHours === 'number'
+      ? incoming.oneTimeOffsetHours
+      : defaults.oneTimeOffsetHours,
+    oneTimeOffsetExpiresAt: typeof incoming?.oneTimeOffsetExpiresAt === 'string'
+      ? incoming.oneTimeOffsetExpiresAt
+      : defaults.oneTimeOffsetExpiresAt,
+    vacationPromptLastShownForUpdatedAt: typeof incoming?.vacationPromptLastShownForUpdatedAt === 'string'
+      ? incoming.vacationPromptLastShownForUpdatedAt
+      : defaults.vacationPromptLastShownForUpdatedAt,
+  };
+
+  return parsed;
 }
 
 export function writeData(data: AppData): void {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,7 +3,7 @@ import type { Settings, UpdateCheckResult } from '../types';
 
 interface Props {
   settings: Settings;
-  onSave: (data: Settings) => Promise<void>;
+  onSave: (data: Partial<Settings>) => Promise<void>;
   updateCheckResult: UpdateCheckResult | null;
   updateCheckError: string | null;
   updateLastCheckedAt: string | null;
@@ -14,20 +14,17 @@ interface Props {
 interface SettingsDraft {
   staleThresholdHours: string;
   topN: string;
-  globalTimeOffset: string;
 }
 
 interface SettingsErrors {
   staleThresholdHours?: string;
   topN?: string;
-  globalTimeOffset?: string;
 }
 
 function toDraft(settings: Settings): SettingsDraft {
   return {
     staleThresholdHours: String(settings.staleThresholdHours),
     topN: String(settings.topN),
-    globalTimeOffset: String(settings.globalTimeOffset),
   };
 }
 
@@ -67,12 +64,11 @@ export default function SettingsPanel({
     setSubmitError(null);
   }, [settings, open]);
 
-  const validate = (): { nextSettings: Settings | null; nextErrors: SettingsErrors } => {
+  const validate = (): { nextSettings: Partial<Settings> | null; nextErrors: SettingsErrors } => {
     const nextErrors: SettingsErrors = {};
 
     const staleThresholdHours = Number(draft.staleThresholdHours);
     const topN = Number(draft.topN);
-    const globalTimeOffset = Number(draft.globalTimeOffset);
 
     if (!Number.isInteger(staleThresholdHours)) {
       nextErrors.staleThresholdHours = 'Enter a whole number.';
@@ -86,12 +82,6 @@ export default function SettingsPanel({
       nextErrors.topN = 'Must be at least 1.';
     }
 
-    if (!Number.isInteger(globalTimeOffset)) {
-      nextErrors.globalTimeOffset = 'Enter a whole number.';
-    } else if (globalTimeOffset < 0) {
-      nextErrors.globalTimeOffset = 'Must be 0 or greater.';
-    }
-
     if (Object.keys(nextErrors).length > 0) {
       return { nextSettings: null, nextErrors };
     }
@@ -100,7 +90,6 @@ export default function SettingsPanel({
       nextSettings: {
         staleThresholdHours: Math.max(1, staleThresholdHours),
         topN: Math.max(1, topN),
-        globalTimeOffset: Math.max(0, globalTimeOffset),
       },
       nextErrors,
     };
@@ -171,18 +160,7 @@ export default function SettingsPanel({
           </label>
           <p className="settings-help">How many prioritized tasks show on Tasks. The rest go to Backlog.</p>
           {errors.topN && <p className="settings-error">{errors.topN}</p>}
-          <label className="settings-field">
-            <span>Vacation offset (hours)</span>
-            <input
-              type="number"
-              value={draft.globalTimeOffset}
-              onChange={e => setDraft(prev => ({ ...prev, globalTimeOffset: e.target.value }))}
-              min={0}
-              disabled={saving}
-            />
-          </label>
-          <p className="settings-help">Extra hours added to the stale threshold while you're away.</p>
-          {errors.globalTimeOffset && <p className="settings-error">{errors.globalTimeOffset}</p>}
+          <p className="settings-help">Vacation adjustments are handled with an inactivity popup when no active task has been updated recently.</p>
 
           <div className="settings-updates-section">
             <h3 className="settings-updates-title">App Updates</h3>

--- a/src/components/VacationNudgeModal.tsx
+++ b/src/components/VacationNudgeModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  open: boolean;
+  suggestedDays: number;
+  inactivityDays: number;
+  isSaving: boolean;
+  onApply: (days: number) => Promise<void>;
+  onSkip: () => Promise<void>;
+}
+
+export default function VacationNudgeModal({
+  open,
+  suggestedDays,
+  inactivityDays,
+  isSaving,
+  onApply,
+  onSkip,
+}: Props) {
+  const [days, setDays] = useState(String(suggestedDays));
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setDays(String(suggestedDays));
+  }, [open, suggestedDays]);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  const parsedDays = Number(days);
+  const validDays = Number.isInteger(parsedDays) && parsedDays >= 1;
+
+  const handleApply = async () => {
+    if (!validDays || isSaving) return;
+    await onApply(parsedDays);
+  };
+
+  const handleSkip = async () => {
+    if (isSaving) return;
+    await onSkip();
+  };
+
+  return (
+    <div className="vacation-nudge-overlay" onClick={() => { void handleSkip(); }}>
+      <div
+        className="vacation-nudge-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Apply vacation offset"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            void handleSkip();
+          }
+        }}
+      >
+        <h2>Vacation Offset</h2>
+        <p className="vacation-nudge-copy">
+          No active task has been updated in about {inactivityDays} day{inactivityDays === 1 ? '' : 's'}.
+        </p>
+        <p className="vacation-nudge-copy">
+          Apply a one-time offset for today?
+        </p>
+        <label className="vacation-nudge-field">
+          <span>Offset (days)</span>
+          <input
+            ref={inputRef}
+            type="number"
+            min={1}
+            step={1}
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            disabled={isSaving}
+          />
+        </label>
+        <div className="vacation-nudge-actions">
+          <button className="btn btn-primary" onClick={() => { void handleApply(); }} disabled={!validDays || isSaving}>
+            {isSaving ? 'Applying...' : 'Apply for today'}
+          </button>
+          <button className="btn" onClick={() => { void handleSkip(); }} disabled={isSaving}>
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -6,12 +6,19 @@ export function useSettings() {
   const [settings, setSettings] = useState<Settings>({
     staleThresholdHours: 24,
     topN: 20,
-    globalTimeOffset: 0,
+    oneTimeOffsetHours: 0,
+    oneTimeOffsetExpiresAt: null,
+    vacationPromptLastShownForUpdatedAt: null,
   });
+  const [loading, setLoading] = useState(true);
 
   const reload = useCallback(async () => {
-    const data = await api.fetchSettings();
-    setSettings(data);
+    try {
+      const data = await api.fetchSettings();
+      setSettings(data);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => { reload(); }, [reload]);
@@ -21,5 +28,5 @@ export function useSettings() {
     setSettings(updated);
   };
 
-  return { settings, reload, update };
+  return { settings, loading, reload, update };
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -709,6 +709,65 @@ textarea:focus-visible,
   padding: 0;
 }
 
+/* Vacation Nudge Modal */
+.vacation-nudge-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--shortcut-overlay);
+  z-index: 210;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vacation-nudge-dialog {
+  background: var(--shortcut-dialog-bg);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  width: min(460px, calc(100vw - 1.5rem));
+  box-shadow: 0 8px 24px var(--shadow-lg);
+}
+
+.vacation-nudge-dialog h2 {
+  font-size: 1.0625rem;
+  margin-bottom: 0.5rem;
+}
+
+.vacation-nudge-copy {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.vacation-nudge-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.vacation-nudge-field span {
+  font-size: 0.8125rem;
+}
+
+.vacation-nudge-field input {
+  width: 88px;
+  padding: 0.25rem 0.375rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.25rem;
+  text-align: right;
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.vacation-nudge-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.875rem;
+}
+
 /* Keyboard Shortcut Overlay */
 .shortcut-overlay {
   position: fixed;
@@ -862,6 +921,25 @@ textarea:focus-visible,
   .settings-update-actions .btn {
     width: 100%;
     text-align: center;
+  }
+
+  .vacation-nudge-field {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.375rem;
+  }
+
+  .vacation-nudge-field input {
+    width: 100%;
+    text-align: left;
+  }
+
+  .vacation-nudge-actions {
+    flex-direction: column;
+  }
+
+  .vacation-nudge-actions .btn {
+    width: 100%;
   }
 
   .toast-container {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,9 @@ export interface Blocker {
 export interface Settings {
   staleThresholdHours: number;
   topN: number;
-  globalTimeOffset: number;
+  oneTimeOffsetHours: number;
+  oneTimeOffsetExpiresAt: string | null;
+  vacationPromptLastShownForUpdatedAt: string | null;
 }
 
 export interface UpdateCheckResult {

--- a/src/utils/staleness.ts
+++ b/src/utils/staleness.ts
@@ -1,6 +1,10 @@
 import type { Settings } from '../types';
 
 export function isStale(updatedAt: string, settings: Settings): boolean {
-  const elapsed = (Date.now() - new Date(updatedAt).getTime()) / 3600000;
-  return elapsed > settings.staleThresholdHours + settings.globalTimeOffset;
+  const now = Date.now();
+  const elapsed = (now - new Date(updatedAt).getTime()) / 3600000;
+  const expiresAt = settings.oneTimeOffsetExpiresAt ? Date.parse(settings.oneTimeOffsetExpiresAt) : NaN;
+  const hasActiveOneTimeOffset = !Number.isNaN(expiresAt) && expiresAt >= now;
+  const effectiveOneTimeOffsetHours = hasActiveOneTimeOffset ? settings.oneTimeOffsetHours : 0;
+  return elapsed > settings.staleThresholdHours + effectiveOneTimeOffsetHours;
 }

--- a/src/utils/vacationNudge.ts
+++ b/src/utils/vacationNudge.ts
@@ -1,0 +1,52 @@
+import type { Settings, Task } from '../types';
+
+export interface VacationNudgeRecommendation {
+  mostRecentActiveUpdatedAt: string;
+  inactivityHours: number;
+  inactivityDays: number;
+  suggestedDays: number;
+}
+
+interface VacationNudgeInput {
+  tasks: Task[];
+  settings: Settings;
+  nowMs?: number;
+}
+
+export function getVacationNudgeRecommendation({
+  tasks,
+  settings,
+  nowMs = Date.now(),
+}: VacationNudgeInput): VacationNudgeRecommendation | null {
+  const activeTasks = tasks.filter(t => t.completedAt == null && !t.isArchived && !t.isDeleted);
+  if (activeTasks.length === 0) return null;
+
+  let mostRecentUpdatedAt: string | null = null;
+  let mostRecentUpdatedMs = -Infinity;
+  for (const task of activeTasks) {
+    const updatedMs = Date.parse(task.updatedAt);
+    if (!Number.isNaN(updatedMs) && updatedMs > mostRecentUpdatedMs) {
+      mostRecentUpdatedMs = updatedMs;
+      mostRecentUpdatedAt = task.updatedAt;
+    }
+  }
+
+  if (!Number.isFinite(mostRecentUpdatedMs) || !mostRecentUpdatedAt) return null;
+
+  const inactivityHours = (nowMs - mostRecentUpdatedMs) / 3600000;
+  if (inactivityHours <= 24) return null;
+
+  if (settings.vacationPromptLastShownForUpdatedAt === mostRecentUpdatedAt) return null;
+
+  const expiresAtMs = settings.oneTimeOffsetExpiresAt ? Date.parse(settings.oneTimeOffsetExpiresAt) : NaN;
+  const hasActiveOneTimeOffset = !Number.isNaN(expiresAtMs) && expiresAtMs > nowMs;
+  if (hasActiveOneTimeOffset) return null;
+
+  const suggestedDays = Math.max(1, Math.floor(inactivityHours / 24));
+  return {
+    mostRecentActiveUpdatedAt: mostRecentUpdatedAt,
+    inactivityHours,
+    inactivityDays: suggestedDays,
+    suggestedDays,
+  };
+}


### PR DESCRIPTION
## Summary
- remove persistent globalTimeOffset from settings schema, API, UI, and staleness logic
- add one-time inactivity vacation nudge popup with apply/skip flows and end-of-day expiration
- add popup eligibility helper and unit tests for inactive >24h and once-per-streak suppression

## Validation
- npm run build
- npm test