### PR TITLE
Add hour-based duration blocking for tasks

### DIFF
--- a/src/components/BlockerForm.tsx
+++ b/src/components/BlockerForm.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAdd }: Props) {
-  const [blockerType, setBlockerType] = useState<'task' | 'date'>('task');
+  const [blockerType, setBlockerType] = useState<'task' | 'date' | 'duration'>('task');
   const [selectedTask, setSelectedTask] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState('');
 
@@ -28,11 +28,17 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
     }
   };
 
+  const handleDuration = async (hours: number) => {
+    const until = new Date(Date.now() + hours * 3600000);
+    await onAdd({ blockedUntilDate: until.toISOString() });
+  };
+
   return (
     <div className="blocker-form">
-      <select value={blockerType} onChange={e => setBlockerType(e.target.value as 'task' | 'date')} aria-label="Blocker type" disabled={isDisabled}>
+      <select value={blockerType} onChange={e => setBlockerType(e.target.value as 'task' | 'date' | 'duration')} aria-label="Blocker type" disabled={isDisabled}>
         <option value="task">Blocked by task</option>
         <option value="date">Blocked until date</option>
+        <option value="duration">Blocked for duration</option>
       </select>
 
       {blockerType === 'task' ? (
@@ -42,7 +48,7 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
             <option key={t.id} value={t.id}>{t.title}</option>
           ))}
         </select>
-      ) : (
+      ) : blockerType === 'date' ? (
         <input
           type="date"
           value={selectedDate}
@@ -50,11 +56,21 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
           aria-label="Blocked until date"
           disabled={isDisabled}
         />
+      ) : (
+        <div className="duration-presets">
+          {[1, 2, 4, 8].map(h => (
+            <button key={h} className="btn btn-sm btn-outline" onClick={() => handleDuration(h)} disabled={isDisabled}>
+              {h}h
+            </button>
+          ))}
+        </div>
       )}
 
-      <button className="btn btn-sm btn-primary" onClick={handleAdd} disabled={isDisabled || (blockerType === 'task' && !selectedTask) || (blockerType === 'date' && !selectedDate)}>
-        Add Blocker
-      </button>
+      {blockerType !== 'duration' && (
+        <button className="btn btn-sm btn-primary" onClick={handleAdd} disabled={isDisabled || (blockerType === 'task' && !selectedTask) || (blockerType === 'date' && !selectedDate)}>
+          Add Blocker
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/BlockerList.tsx
+++ b/src/components/BlockerList.tsx
@@ -19,13 +19,25 @@ export default function BlockerList({ blockers, allTasks, onRemove, isDisabled =
           ? allTasks.find(t => t.id === b.blockedByTaskId)
           : null;
 
+        const formatBlockedUntil = (iso: string) => {
+          const d = new Date(iso);
+          const now = new Date();
+          const isToday = d.getFullYear() === now.getFullYear()
+            && d.getMonth() === now.getMonth()
+            && d.getDate() === now.getDate();
+          if (isToday) {
+            return `Blocked until ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+          }
+          return `Blocked until ${d.toLocaleDateString([], { month: 'short', day: 'numeric' })}, ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+        };
+
         return (
           <div key={b.id} className="blocker-item">
             <span>
               {blockingTask
                 ? `Blocked by: ${blockingTask.title}`
                 : b.blockedUntilDate
-                  ? `Blocked until: ${new Date(b.blockedUntilDate).toLocaleDateString()}`
+                  ? formatBlockedUntil(b.blockedUntilDate)
                   : 'Unknown blocker'}
             </span>
             <button className="btn btn-sm btn-danger" onClick={() => onRemove(b.id)} disabled={isDisabled}>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -510,6 +510,22 @@ textarea:focus-visible,
   color: var(--text-primary);
 }
 
+.duration-presets {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.btn-outline {
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: var(--border-default);
+}
+
 /* Settings */
 .settings-panel {
   position: relative;


### PR DESCRIPTION
## Summary
- Add a "Blocked for duration" option to the blocker form with 1h, 2h, 4h, and 8h preset buttons
- Update blocker display to show the expiry time (e.g. "Blocked until 2:30 PM") instead of just the date
- No backend changes needed -- existing blockedUntilDate and autoUnblock() already handle time-level precision

## Test plan
- [ ] Open a task blocker form, select "Blocked for duration", click a preset (e.g. 1h)
- [ ] Verify the task moves to the Blocked tab
- [ ] Verify the blocker shows the expiry time (time-only for today, date+time for future)
- [ ] Verify the task auto-unblocks when the time passes