### PR TITLE
Merge Archive and Trash into single Archive tab

### DIFF
--- a/server/__tests__/helpers.ts
+++ b/server/__tests__/helpers.ts
@@ -14,7 +14,6 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     updatedAt: now,
     completedAt: null,
     isArchived: false,
-    isDeleted: false,
     ...overrides,
   };
 }

--- a/server/__tests__/task-logic.test.ts
+++ b/server/__tests__/task-logic.test.ts
@@ -158,13 +158,6 @@ describe('getPrioritizedTasks', () => {
       expect(getPrioritizedTasks(data)).toHaveLength(0);
     });
 
-    it('excludes deleted tasks', () => {
-      const data = makeAppData({
-        tasks: [makeTask({ id: 1, isDeleted: true })],
-      });
-      expect(getPrioritizedTasks(data)).toHaveLength(0);
-    });
-
     it('excludes completed tasks', () => {
       const data = makeAppData({
         tasks: [makeTask({ id: 1, completedAt: '2024-01-01T00:00:00Z' })],
@@ -306,8 +299,7 @@ describe('getPrioritizedTasks', () => {
       const data = makeAppData({
         tasks: [
           makeTask({ id: 1, isArchived: true }),
-          makeTask({ id: 2, isDeleted: true }),
-          makeTask({ id: 3, completedAt: '2024-01-01T00:00:00Z' }),
+          makeTask({ id: 2, completedAt: '2024-01-01T00:00:00Z' }),
           makeTask({ id: 4, priority: null }),
         ],
       });

--- a/server/task-logic.ts
+++ b/server/task-logic.ts
@@ -34,7 +34,7 @@ export function hasUnresolvedBlockers(taskId: number, data: AppData): boolean {
 
 export function getPrioritizedTasks(data: AppData): Task[] {
   return data.tasks
-    .filter(t => t.priority != null && !t.isArchived && !t.isDeleted && t.completedAt == null && !hasUnresolvedBlockers(t.id, data))
+    .filter(t => t.priority != null && !t.isArchived && t.completedAt == null && !hasUnresolvedBlockers(t.id, data))
     .sort((a, b) => {
       const pa = PRIORITY_ORDER[a.priority!] ?? 99;
       const pb = PRIORITY_ORDER[b.priority!] ?? 99;

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ export const fetchTasks = (tab: TabName) =>
 export const createTask = (data: { title: string; status?: string; priority?: string | null }) =>
   request<Task>('/tasks', { method: 'POST', body: JSON.stringify(data) });
 
-export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) =>
+export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) =>
   request<Task>(`/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) });
 
 export const completeTask = (id: number) =>
@@ -34,10 +34,7 @@ export const uncompleteTask = (id: number) =>
   request<Task>(`/tasks/${id}/uncomplete`, { method: 'POST' });
 
 export const deleteTask = (id: number) =>
-  request<Task>(`/tasks/${id}`, { method: 'DELETE' });
-
-export const permanentDeleteTask = (id: number) =>
-  request<void>(`/tasks/${id}?permanent=true`, { method: 'DELETE' });
+  request<void>(`/tasks/${id}`, { method: 'DELETE' });
 
 // Blockers
 export const fetchBlockers = (taskId: number) =>

--- a/src/components/BlockerForm.tsx
+++ b/src/components/BlockerForm.tsx
@@ -14,7 +14,7 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
   const [selectedDate, setSelectedDate] = useState('');
 
   const otherTasks = allTasks.filter(
-    t => t.id !== taskId && t.completedAt == null && !t.isArchived && !t.isDeleted
+    t => t.id !== taskId && t.completedAt == null && !t.isArchived
   );
 
   const handleAdd = async () => {

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -13,7 +13,6 @@ const TABS: { key: TabName; label: string }[] = [
   { key: 'blocked', label: 'Blocked' },
   { key: 'completed', label: 'Completed' },
   { key: 'archive', label: 'Archive' },
-  { key: 'trash', label: 'Trash' },
 ];
 
 export default function TabBar({ activeTab, onTabChange, counts }: Props) {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -15,10 +15,9 @@ interface Props {
   blockers: Blocker[];
   activeTab: TabName;
   recentlyUpdated?: boolean;
-  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) => Promise<void>;
+  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
-  onDelete: (id: number) => Promise<void>;
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
@@ -33,7 +32,7 @@ const ROW_COLORS: Record<string, string> = {
 
 export default function TaskRow({
   task, settings, showStaleness, isPending, allTasks, blockers, activeTab, recentlyUpdated,
-  onUpdate, onComplete, onUncomplete, onDelete,
+  onUpdate, onComplete, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete,
 }: Props) {
   const [editingTitle, setEditingTitle] = useState(false);
@@ -198,37 +197,30 @@ export default function TaskRow({
         </div>
 
         <div className="task-actions">
-          {task.isDeleted ? (
+          {activeTab === 'completed' ? (
             <>
-              <button className="btn btn-sm btn-primary" onClick={() => onUpdate(task.id, { isDeleted: false })} disabled={isPending} aria-label={`Restore ${task.title}`}>Restore</button>
+              <button className="btn btn-sm" onClick={() => onUncomplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as not completed`}>Undo</button>
+              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+            </>
+          ) : activeTab === 'archive' ? (
+            <>
+              <button className="btn btn-sm btn-primary" onClick={() => onUpdate(task.id, { isArchived: false })} disabled={isPending} aria-label={`Unarchive ${task.title}`}>Unarchive</button>
               <button className="btn btn-sm btn-danger" onClick={() => {
                 if (window.confirm('Permanently delete this task? This cannot be undone.')) {
                   onPermanentDelete(task.id);
                 }
               }} disabled={isPending} aria-label={`Permanently delete ${task.title}`}>Permanently Delete</button>
             </>
-          ) : activeTab === 'completed' ? (
-            <>
-              <button className="btn btn-sm" onClick={() => onUncomplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as not completed`}>Undo</button>
-              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-danger" onClick={() => onDelete(task.id)} disabled={isPending} aria-label={`Delete ${task.title}`}>Delete</button>
-            </>
-          ) : activeTab === 'archive' ? (
-            <>
-              <button className="btn btn-sm btn-primary" onClick={() => onUpdate(task.id, { isArchived: false })} disabled={isPending} aria-label={`Unarchive ${task.title}`}>Unarchive</button>
-              <button className="btn btn-sm btn-danger" onClick={() => onDelete(task.id)} disabled={isPending} aria-label={`Delete ${task.title}`}>Delete</button>
-            </>
           ) : activeTab === 'ideas' ? (
             <>
               <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
-              <button className="btn btn-sm btn-danger" onClick={() => onDelete(task.id)} disabled={isPending} aria-label={`Delete ${task.title}`}>Delete</button>
+              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
             </>
           ) : (
             <>
               <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Blockers</button>
-              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: !task.isArchived })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-danger" onClick={() => onDelete(task.id)} disabled={isPending} aria-label={`Delete ${task.title}`}>Delete</button>
+              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
             </>
           )}
         </div>

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -13,10 +13,9 @@ interface Props {
   loading: boolean;
   recentlyUpdatedIds?: Set<number>;
   onTabChange: (tab: TabName) => void;
-  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) => Promise<void>;
+  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
-  onDelete: (id: number) => Promise<void>;
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
   onRemoveBlocker: (blockerId: number, taskId: number) => Promise<void>;
@@ -26,7 +25,7 @@ interface Props {
 
 export default function TaskTable({
   tasks, searchQuery, hasActiveSearch, settings, allTasks, blockers, pendingActionByTaskId, activeTab, loading, recentlyUpdatedIds,
-  onTabChange, onUpdate, onComplete, onUncomplete, onDelete,
+  onTabChange, onUpdate, onComplete, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete, onClearSearch,
 }: Props) {
   const showStaleness = activeTab === 'tasks';
@@ -59,10 +58,6 @@ export default function TaskTable({
     archive: {
       title: 'No archived tasks',
       description: 'Archive items you want to keep but hide from active views.',
-    },
-    trash: {
-      title: 'Trash is empty',
-      description: 'Nothing deleted yet.',
     },
   };
 
@@ -114,7 +109,6 @@ export default function TaskTable({
           onUpdate={onUpdate}
           onComplete={onComplete}
           onUncomplete={onUncomplete}
-          onDelete={onDelete}
           onLoadBlockers={onLoadBlockers}
           onAddBlocker={onAddBlocker}
           onRemoveBlocker={onRemoveBlocker}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -33,7 +33,7 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
-  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'isDeleted'>>) => {
+  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => {
     await api.updateTask(id, data);
     await reload();
   };
@@ -53,10 +53,5 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
-  const permanentRemove = async (id: number) => {
-    await api.permanentDeleteTask(id);
-    await reload();
-  };
-
-  return { tasks, loading, reload, create, update, complete, uncomplete, remove, permanentRemove };
+  return { tasks, loading, reload, create, update, complete, uncomplete, remove };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface Task {
   updatedAt: string;
   completedAt: string | null;
   isArchived: boolean;
-  isDeleted: boolean;
 }
 
 export interface Blocker {
@@ -36,4 +35,4 @@ export interface UpdateCheckResult {
   checkedAt: string;
 }
 
-export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive' | 'trash';
+export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive';

--- a/src/utils/vacationNudge.ts
+++ b/src/utils/vacationNudge.ts
@@ -18,7 +18,7 @@ export function getVacationNudgeRecommendation({
   settings,
   nowMs = Date.now(),
 }: VacationNudgeInput): VacationNudgeRecommendation | null {
-  const activeTasks = tasks.filter(t => t.completedAt == null && !t.isArchived && !t.isDeleted);
+  const activeTasks = tasks.filter(t => t.completedAt == null && !t.isArchived);
   if (activeTasks.length === 0) return null;
 
   let mostRecentUpdatedAt: string | null = null;


### PR DESCRIPTION
## Summary
- Consolidates Archive and Trash into a single Archive tab, removing `isDeleted` field and the Trash tab entirely
- Archiving a task now auto-resolves its dependent blockers (behavior previously only on soft-delete)
- Permanent delete is available from the Archive tab with a confirmation dialog
- Data migration converts existing `isDeleted: true` tasks to `isArchived: true` on first read

## Button layout changes

| Tab | Before | After |
|-----|--------|-------|
| Active (tasks/backlog/blocked) | Done, Blockers, Archive, Delete | Done, Blockers, Archive |
| Ideas | Done, Delete | Done, Archive |
| Completed | Undo, Archive, Delete | Undo, Archive |
| Archive | Unarchive, Delete | Unarchive, Permanently Delete |
| Trash | Restore, Permanently Delete | *(tab removed)* |

## Test plan
- [x] Both frontend and server type-checks pass
- [x] All 88 tests pass (7 test files)
- [x] Trash tab is removed (6 tabs total)
- [x] Active tasks show Done/Blockers/Archive (no Delete)
- [x] Ideas show Done/Archive (no Delete)
- [x] Completed shows Undo/Archive (no Delete)
- [x] Archive shows Unarchive + Permanently Delete (with confirm dialog)
- [x] Previously deleted tasks migrated to Archive
- [x] Archiving a blocking task resolves dependent blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)