### PR TITLE
Add fast task rotation with Next action and shortcut

### DIFF
--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -338,6 +338,29 @@ describe('PUT /tasks/:id', () => {
     expect(updated.priority).toBe('P1');
   });
 
+  it('supports no-op update for rotation by touching only updatedAt', () => {
+    const task = makeTask({
+      id: 1,
+      title: 'Original',
+      status: 'Active',
+      priority: 'P1',
+      isArchived: false,
+      updatedAt: '2024-01-01T00:00:00Z',
+    });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: {} }), res);
+
+    const updated = res.json.mock.calls[0][0];
+    expect(updated.title).toBe('Original');
+    expect(updated.status).toBe('Active');
+    expect(updated.priority).toBe('P1');
+    expect(updated.isArchived).toBe(false);
+    expect(updated.updatedAt).not.toBe('2024-01-01T00:00:00Z');
+  });
+
   it('sets priority to null when falsy value provided', () => {
     const task = makeTask({ id: 1, priority: 'P0' });
     const data = makeAppData({ tasks: [task] });

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -17,6 +17,7 @@ interface Props {
   recentlyUpdated?: boolean;
   onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
+  onSkip: (id: number) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
@@ -32,7 +33,7 @@ const ROW_COLORS: Record<string, string> = {
 
 export default function TaskRow({
   task, settings, showStaleness, isPending, allTasks, blockers, activeTab, recentlyUpdated,
-  onUpdate, onComplete, onUncomplete,
+  onUpdate, onComplete, onSkip, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete,
 }: Props) {
   const [editingTitle, setEditingTitle] = useState(false);
@@ -214,6 +215,13 @@ export default function TaskRow({
           ) : activeTab === 'ideas' ? (
             <>
               <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+            </>
+          ) : activeTab === 'tasks' ? (
+            <>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-primary" onClick={() => onSkip(task.id)} disabled={isPending} aria-label={`Move to next task after ${task.title}`}>Next</button>
+              <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Blockers</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
             </>
           ) : (

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -15,6 +15,7 @@ interface Props {
   onTabChange: (tab: TabName) => void;
   onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
+  onSkip: (id: number) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
   onLoadBlockers: (taskId: number) => Promise<void>;
   onAddBlocker: (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
@@ -25,7 +26,7 @@ interface Props {
 
 export default function TaskTable({
   tasks, searchQuery, hasActiveSearch, settings, allTasks, blockers, pendingActionByTaskId, activeTab, loading, recentlyUpdatedIds,
-  onTabChange, onUpdate, onComplete, onUncomplete,
+  onTabChange, onUpdate, onComplete, onSkip, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete, onClearSearch,
 }: Props) {
   const showStaleness = activeTab === 'tasks';
@@ -108,6 +109,7 @@ export default function TaskTable({
           recentlyUpdated={recentlyUpdatedIds?.has(task.id)}
           onUpdate={onUpdate}
           onComplete={onComplete}
+          onSkip={onSkip}
           onUncomplete={onUncomplete}
           onLoadBlockers={onLoadBlockers}
           onAddBlocker={onAddBlocker}


### PR DESCRIPTION
## Summary
- add a "Next" action for tasks in the Tasks tab so a task can be rotated without changing status text
- add keyboard shortcut `N` to skip the current top task in Tasks
- implement skip as a no-op task update so `updatedAt` changes and ordering/staleness update naturally
- add route test coverage for empty-body `PUT /tasks/:id` touching only `updatedAt`

## Validation
- npm test
- npm run build