### PR TITLE
Fix time block details disappearing on blocked tab revisit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,13 +264,13 @@ export default function App() {
     }, 'Task permanently deleted.');
   };
 
-  const handleLoadBlockers = async (taskId: number) => {
+  const handleLoadBlockers = useCallback(async (taskId: number) => {
     try {
       await loadForTask(taskId);
     } catch (error) {
       showToast(getErrorMessage(error), 'error');
     }
-  };
+  }, [loadForTask, showToast]);
 
   const handleAddBlocker = async (taskId: number, data: { blockedByTaskId?: number; blockedUntilDate?: string }) => {
     await runTaskAction(taskId, async () => {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -66,6 +66,13 @@ export default function TaskRow({
     }
   }, [editingStatus, autoResizeTextarea]);
 
+  // Auto-load blockers when mounting on the blocked tab
+  useEffect(() => {
+    if (activeTab === 'blocked') {
+      void onLoadBlockers(task.id);
+    }
+  }, [activeTab, task.id, onLoadBlockers]);
+
   const saveTitle = async () => {
     setEditingTitle(false);
     if (titleValue.trim() && titleValue !== task.title) {


### PR DESCRIPTION
## Summary
- Fixed a bug where time-based blocker details (e.g. "Blocked until 3:00 PM") would disappear from the Blocked tab after navigating away and back
- Added a `useEffect` in `TaskRow` to auto-load blockers when mounting on the blocked tab
- Wrapped `handleLoadBlockers` in `useCallback` to stabilize the reference and prevent re-render loops

## Test plan
- [ ] Create a task and add a time-based blocker (e.g. 4 hours)
- [ ] Navigate to the Blocked tab — verify blocker details show
- [ ] Navigate to the Tasks tab, then back to the Blocked tab — verify blocker details still show
- [ ] Click the "Blockers" button to toggle the section off/on — verify it still works correctly
- [ ] Run `npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)