### PR TITLE
Add seamless self-update flow and durable data migration

### DIFF
--- a/scripts/install-service.js
+++ b/scripts/install-service.js
@@ -1,12 +1,20 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectDir = path.resolve(__dirname, '..');
-const plistPath = path.join(process.env.HOME, 'Library/LaunchAgents/com.stradl.server.plist');
+const homeDir = process.env.HOME || os.homedir();
+const plistPath = path.join(homeDir, 'Library/LaunchAgents/com.stradl.server.plist');
+const configuredDataDir = process.env.STRADL_DATA_DIR?.trim();
+const dataDir = configuredDataDir
+  ? path.resolve(configuredDataDir)
+  : path.join(homeDir, 'Library', 'Application Support', 'Stradl');
 const nodePath = execSync('which node').toString().trim();
+
+fs.mkdirSync(dataDir, { recursive: true });
 
 const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -26,9 +34,9 @@ const plist = `<?xml version="1.0" encoding="UTF-8"?>
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${projectDir}/data/server.log</string>
+  <string>${dataDir}/server.log</string>
   <key>StandardErrorPath</key>
-  <string>${projectDir}/data/server-error.log</string>
+  <string>${dataDir}/server-error.log</string>
 </dict>
 </plist>`;
 

--- a/scripts/self-update.js
+++ b/scripts/self-update.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      parsed[key] = 'true';
+      continue;
+    }
+    parsed[key] = value;
+    i += 1;
+  }
+  return parsed;
+}
+
+function formatCommandError(error) {
+  if (!error || typeof error !== 'object') {
+    return 'Command failed.';
+  }
+
+  const maybeError = error;
+  const stderr = typeof maybeError.stderr === 'string'
+    ? maybeError.stderr.trim()
+    : Buffer.isBuffer(maybeError.stderr)
+      ? maybeError.stderr.toString('utf-8').trim()
+      : '';
+  if (stderr) return stderr;
+
+  const stdout = typeof maybeError.stdout === 'string'
+    ? maybeError.stdout.trim()
+    : Buffer.isBuffer(maybeError.stdout)
+      ? maybeError.stdout.toString('utf-8').trim()
+      : '';
+  if (stdout) return stdout;
+
+  if (maybeError instanceof Error && maybeError.message) {
+    return maybeError.message;
+  }
+  return 'Command failed.';
+}
+
+function readLocalVersion(projectRoot) {
+  const packagePath = path.join(projectRoot, 'package.json');
+  const raw = fs.readFileSync(packagePath, 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (!parsed.version || typeof parsed.version !== 'string') {
+    throw new Error('App version missing.');
+  }
+  return parsed.version.replace(/^v/i, '').trim();
+}
+
+function runCommand(command, cwd) {
+  try {
+    execSync(command, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+  } catch (error) {
+    throw new Error(formatCommandError(error));
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const statusFile = args['status-file'];
+const operationId = args['operation-id'];
+const startedAt = args['started-at'] || new Date().toISOString();
+const projectRoot = process.cwd();
+
+if (!statusFile || !operationId) {
+  console.error('Usage: node scripts/self-update.js --status-file <path> --operation-id <id> [--started-at <iso>] [--from-version <ver>]');
+  process.exit(1);
+}
+
+const state = {
+  state: 'running',
+  step: 'starting',
+  operationId,
+  startedAt,
+  fromVersion: typeof args['from-version'] === 'string' ? args['from-version'] : undefined,
+  toVersion: undefined,
+  message: 'Starting self-update.',
+  finishedAt: undefined,
+};
+
+function writeStatus() {
+  fs.mkdirSync(path.dirname(statusFile), { recursive: true });
+  fs.writeFileSync(statusFile, JSON.stringify(state, null, 2));
+}
+
+function setStep(step, message) {
+  state.state = 'running';
+  state.step = step;
+  state.message = message;
+  writeStatus();
+}
+
+function markFailed(message) {
+  state.state = 'failed';
+  state.message = message;
+  state.finishedAt = new Date().toISOString();
+  writeStatus();
+}
+
+function markSucceeded() {
+  state.state = 'succeeded';
+  state.step = 'completed';
+  state.message = 'Update applied successfully.';
+  state.finishedAt = new Date().toISOString();
+  writeStatus();
+}
+
+try {
+  if (!state.fromVersion) {
+    state.fromVersion = readLocalVersion(projectRoot);
+  }
+  writeStatus();
+
+  setStep('fetching', 'Fetching latest origin/main.');
+  runCommand('git fetch origin main', projectRoot);
+
+  setStep('pulling', 'Pulling latest origin/main.');
+  runCommand('git pull --ff-only origin main', projectRoot);
+
+  setStep('installing-dependencies', 'Installing dependencies.');
+  runCommand('npm ci --include=dev', projectRoot);
+
+  setStep('building', 'Building application.');
+  runCommand('npm run build', projectRoot);
+
+  state.toVersion = readLocalVersion(projectRoot);
+
+  const uid = typeof process.getuid === 'function'
+    ? String(process.getuid())
+    : process.env.UID;
+  if (!uid) {
+    throw new Error('Unable to determine user id for launchctl.');
+  }
+
+  setStep('restarting', 'Restarting LaunchAgent service.');
+  runCommand(`launchctl kickstart -k gui/${uid}/com.stradl.server`, projectRoot);
+
+  markSucceeded();
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'Self-update failed.';
+  markFailed(message);
+  process.exit(1);
+}

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readDataFromPaths, resolveStoragePaths } from '../storage.js';
+
+function makeAppData(title: string) {
+  const now = '2026-02-24T00:00:00.000Z';
+  return {
+    tasks: [
+      {
+        id: 1,
+        title,
+        status: '',
+        priority: 'P1',
+        createdAt: now,
+        updatedAt: now,
+        completedAt: null,
+        isArchived: false,
+      },
+    ],
+    blockers: [],
+    settings: {
+      staleThresholdHours: 48,
+      topN: 20,
+      oneTimeOffsetHours: 0,
+      oneTimeOffsetExpiresAt: null,
+      vacationPromptLastShownForUpdatedAt: null,
+    },
+    nextTaskId: 2,
+    nextBlockerId: 1,
+  };
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+const tempRoots: string[] = [];
+
+function createProjectPaths() {
+  const projectRoot = fs.mkdtempSync(path.join(process.cwd(), 'tmp-storage-'));
+  const homeDir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-storage-home-'));
+  tempRoots.push(projectRoot, homeDir);
+
+  const paths = resolveStoragePaths({
+    projectRoot,
+    platform: 'darwin',
+    homeDir,
+    env: {},
+  });
+
+  return { projectRoot, paths };
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0, tempRoots.length)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('storage migration pathing', () => {
+  it('migrates from project data/tasks.json when destination does not exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(path.join(projectRoot, 'data', 'tasks.json'), makeAppData('from-project-data'));
+
+    const data = readDataFromPaths(paths);
+
+    expect(data.tasks[0].title).toBe('from-project-data');
+    expect(fs.existsSync(paths.dataFile)).toBe(true);
+  });
+
+  it('migrates from project server/data/tasks.json when destination does not exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(path.join(projectRoot, 'server', 'data', 'tasks.json'), makeAppData('from-server-data'));
+
+    const data = readDataFromPaths(paths);
+
+    expect(data.tasks[0].title).toBe('from-server-data');
+    expect(fs.existsSync(paths.dataFile)).toBe(true);
+  });
+
+  it('prefers the newest legacy file when both legacy locations exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    const legacyProjectData = path.join(projectRoot, 'data', 'tasks.json');
+    const legacyServerData = path.join(projectRoot, 'server', 'data', 'tasks.json');
+
+    writeJson(legacyProjectData, makeAppData('older-source'));
+    writeJson(legacyServerData, makeAppData('newer-source'));
+    const now = new Date();
+    const older = new Date(now.getTime() - 60_000);
+    fs.utimesSync(legacyProjectData, older, older);
+    fs.utimesSync(legacyServerData, now, now);
+
+    const data = readDataFromPaths(paths);
+    expect(data.tasks[0].title).toBe('newer-source');
+  });
+
+  it('does not overwrite existing app-support data file', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(paths.dataFile, makeAppData('existing-target'));
+    writeJson(path.join(projectRoot, 'data', 'tasks.json'), makeAppData('legacy-source'));
+
+    const data = readDataFromPaths(paths);
+    expect(data.tasks[0].title).toBe('existing-target');
+  });
+});

--- a/server/routes/update.ts
+++ b/server/routes/update.ts
@@ -1,7 +1,9 @@
+import * as childProcess from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import type { Request } from 'express';
 import { Router } from 'express';
+import { findProjectRoot, getDataDirectory } from '../storage.js';
 
 interface GitHubRelease {
   tag_name: string;
@@ -10,23 +12,39 @@ interface GitHubRelease {
   name?: string;
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export type UpdateApplyState = 'idle' | 'running' | 'succeeded' | 'failed';
 
-function findProjectRoot(): string {
-  const candidates = [
-    path.resolve(__dirname, '../../..'),
-    path.resolve(__dirname, '../..'),
-  ];
+interface UpdateApplyStatus {
+  state: UpdateApplyState;
+  step: string;
+  message?: string;
+  operationId?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
 
-  const resolved = candidates.find((candidate) =>
-    fs.existsSync(path.join(candidate, 'package.json'))
-  );
+interface UpdateApplyStartResponse {
+  operationId: string;
+  startedAt: string;
+  targetVersion?: string;
+}
 
-  if (!resolved) {
-    throw new Error('Project root not found.');
+const SELF_UPDATE_FLAG = 'STRADL_ENABLE_SELF_UPDATE';
+const UPDATE_STATUS_FILE = 'update-status.json';
+const LAUNCH_AGENT_LABEL = 'com.stradl.server';
+const PROJECT_ROOT = findProjectRoot();
+
+let updateInFlight = false;
+
+class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
   }
-
-  return resolved;
 }
 
 function normalizeVersion(value: string): string {
@@ -52,7 +70,7 @@ function isVersionNewer(latest: string, current: string): boolean {
 }
 
 function readCurrentVersion(): string {
-  const packagePath = path.join(findProjectRoot(), 'package.json');
+  const packagePath = path.join(PROJECT_ROOT, 'package.json');
   const raw = fs.readFileSync(packagePath, 'utf-8');
   const parsed = JSON.parse(raw) as { version?: string };
 
@@ -61,6 +79,142 @@ function readCurrentVersion(): string {
   }
 
   return normalizeVersion(parsed.version);
+}
+
+export function isSelfUpdateEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[SELF_UPDATE_FLAG] === 'true';
+}
+
+export function isLoopbackAddress(address: string | undefined | null): boolean {
+  if (!address) return false;
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+function isLocalRequest(req: Request): boolean {
+  return isLoopbackAddress(req.ip) || isLoopbackAddress(req.socket.remoteAddress);
+}
+
+function runCapture(command: string, cwd: string): string {
+  return childProcess.execSync(command, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function getLaunchAgentPath(): string {
+  const home = process.env.HOME;
+  if (!home) {
+    throw new HttpError(400, 'HOME is not set; cannot verify LaunchAgent installation.');
+  }
+  return path.join(home, 'Library', 'LaunchAgents', `${LAUNCH_AGENT_LABEL}.plist`);
+}
+
+function ensureLaunchAgentInstalled(): void {
+  const launchAgentPath = getLaunchAgentPath();
+  if (!fs.existsSync(launchAgentPath)) {
+    throw new HttpError(
+      400,
+      `LaunchAgent is not installed (${launchAgentPath}). Run npm run install-service first.`
+    );
+  }
+}
+
+function ensureCleanWorkingTree(projectRoot: string): void {
+  let statusOutput: string;
+  try {
+    statusOutput = runCapture('git status --porcelain', projectRoot);
+  } catch {
+    throw new HttpError(500, 'Failed to inspect git working tree.');
+  }
+
+  if (statusOutput) {
+    throw new HttpError(
+      409,
+      'Update blocked: working tree has local changes. Commit or stash changes before updating.'
+    );
+  }
+}
+
+function getUpdateStatusPath(): string {
+  return path.join(getDataDirectory(), UPDATE_STATUS_FILE);
+}
+
+function writeUpdateApplyStatus(status: UpdateApplyStatus): void {
+  const statusPath = getUpdateStatusPath();
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
+}
+
+function readUpdateApplyStatus(): UpdateApplyStatus {
+  const statusPath = getUpdateStatusPath();
+  if (!fs.existsSync(statusPath)) {
+    updateInFlight = false;
+    return { state: 'idle', step: 'idle' };
+  }
+
+  try {
+    const raw = fs.readFileSync(statusPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<UpdateApplyStatus>;
+    if (
+      parsed.state !== 'idle' &&
+      parsed.state !== 'running' &&
+      parsed.state !== 'succeeded' &&
+      parsed.state !== 'failed'
+    ) {
+      return { state: 'idle', step: 'idle' };
+    }
+
+    const step = typeof parsed.step === 'string' ? parsed.step : 'idle';
+    const status: UpdateApplyStatus = {
+      state: parsed.state,
+      step,
+      message: typeof parsed.message === 'string' ? parsed.message : undefined,
+      operationId: typeof parsed.operationId === 'string' ? parsed.operationId : undefined,
+      startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : undefined,
+      finishedAt: typeof parsed.finishedAt === 'string' ? parsed.finishedAt : undefined,
+      fromVersion: typeof parsed.fromVersion === 'string' ? parsed.fromVersion : undefined,
+      toVersion: typeof parsed.toVersion === 'string' ? parsed.toVersion : undefined,
+    };
+
+    if (status.state !== 'running') {
+      updateInFlight = false;
+    }
+
+    return status;
+  } catch {
+    return { state: 'idle', step: 'idle' };
+  }
+}
+
+function spawnSelfUpdateProcess(args: {
+  operationId: string;
+  startedAt: string;
+  fromVersion: string;
+}): void {
+  const statusPath = getUpdateStatusPath();
+  const scriptPath = path.join(PROJECT_ROOT, 'scripts', 'self-update.js');
+
+  if (!fs.existsSync(scriptPath)) {
+    throw new HttpError(500, `Self-update script missing: ${scriptPath}`);
+  }
+
+  const child = childProcess.spawn(
+    process.execPath,
+    [
+      scriptPath,
+      '--status-file', statusPath,
+      '--operation-id', args.operationId,
+      '--started-at', args.startedAt,
+      '--from-version', args.fromVersion,
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      detached: true,
+      stdio: 'ignore',
+    }
+  );
+  child.unref();
 }
 
 export const updateRoutes = Router();
@@ -138,4 +292,71 @@ updateRoutes.get('/update-check', async (_req, res) => {
     publishedAt: release.published_at,
     checkedAt,
   });
+});
+
+updateRoutes.post('/update-apply', (req, res) => {
+  let statusInitialized = false;
+  try {
+    if (!isSelfUpdateEnabled()) {
+      throw new HttpError(403, `Self-update is disabled. Set ${SELF_UPDATE_FLAG}=true to enable.`);
+    }
+
+    if (!isLocalRequest(req)) {
+      throw new HttpError(403, 'Self-update is only allowed from localhost.');
+    }
+
+    const existingStatus = readUpdateApplyStatus();
+    if (updateInFlight || existingStatus.state === 'running') {
+      throw new HttpError(409, 'An update is already running.');
+    }
+
+    ensureLaunchAgentInstalled();
+    ensureCleanWorkingTree(PROJECT_ROOT);
+
+    let fromVersion: string;
+    try {
+      fromVersion = readCurrentVersion();
+    } catch {
+      throw new HttpError(500, 'Failed to read local app version.');
+    }
+
+    const operationId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const startedAt = new Date().toISOString();
+    writeUpdateApplyStatus({
+      state: 'running',
+      step: 'queued',
+      message: 'Update queued.',
+      operationId,
+      startedAt,
+      fromVersion,
+    });
+    statusInitialized = true;
+
+    spawnSelfUpdateProcess({ operationId, startedAt, fromVersion });
+    updateInFlight = true;
+
+    const payload: UpdateApplyStartResponse = { operationId, startedAt };
+    res.status(202).json(payload);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to start update.';
+    if (statusInitialized) {
+      writeUpdateApplyStatus({
+        state: 'failed',
+        step: 'start',
+        message,
+        finishedAt: new Date().toISOString(),
+      });
+    }
+    updateInFlight = false;
+
+    if (error instanceof HttpError) {
+      res.status(error.status).send(message);
+      return;
+    }
+    res.status(500).send(message);
+  }
+});
+
+updateRoutes.get('/update-apply-status', (_req, res) => {
+  res.json(readUpdateApplyStatus());
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,12 @@
-import type { Task, Blocker, Settings, TabName, UpdateCheckResult } from './types';
+import type {
+  Task,
+  Blocker,
+  Settings,
+  TabName,
+  UpdateCheckResult,
+  UpdateApplyStartResult,
+  UpdateApplyStatus,
+} from './types';
 
 const BASE = '/api';
 
@@ -56,3 +64,9 @@ export const updateSettings = (data: Partial<Settings>) =>
 // Updates
 export const checkForUpdates = () =>
   request<UpdateCheckResult>('/update-check');
+
+export const applyUpdate = () =>
+  request<UpdateApplyStartResult>('/update-apply', { method: 'POST' });
+
+export const fetchUpdateApplyStatus = () =>
+  request<UpdateApplyStatus>('/update-apply-status');

--- a/src/hooks/useApplyUpdate.ts
+++ b/src/hooks/useApplyUpdate.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { UpdateApplyStatus } from '../types';
+import * as api from '../api';
+
+const POLL_INTERVAL_MS = 2000;
+
+function getMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return 'Failed to process update request.';
+}
+
+interface RefreshOptions {
+  suppressError?: boolean;
+}
+
+export function useApplyUpdate() {
+  const [status, setStatus] = useState<UpdateApplyStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshStatus = useCallback(async (options?: RefreshOptions) => {
+    const suppressError = options?.suppressError ?? false;
+    try {
+      const next = await api.fetchUpdateApplyStatus();
+      setStatus(next);
+      setError(null);
+      return next;
+    } catch (err) {
+      if (!suppressError) {
+        setError(getMessage(err));
+      }
+      throw err;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status?.state !== 'running') return;
+
+    const timer = window.setInterval(() => {
+      void refreshStatus({ suppressError: true });
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refreshStatus, status?.state]);
+
+  const applyNow = useCallback(async () => {
+    setError(null);
+    try {
+      const started = await api.applyUpdate();
+      setStatus({
+        state: 'running',
+        step: 'queued',
+        operationId: started.operationId,
+        startedAt: started.startedAt,
+        toVersion: started.targetVersion,
+      });
+      await refreshStatus({ suppressError: true });
+    } catch (error) {
+      const message = getMessage(error);
+      setError(message);
+      throw new Error(message);
+    }
+  }, [refreshStatus]);
+
+  return {
+    status,
+    error,
+    isApplying: status?.state === 'running',
+    applyNow,
+    refreshStatus,
+  };
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -607,6 +607,15 @@ textarea:focus-visible,
   margin-top: 0.25rem;
 }
 
+.settings-update-progress {
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+}
+
+.settings-update-message {
+  margin-top: -0.25rem;
+}
+
 /* Dark Mode Toggle */
 .theme-toggle {
   border: none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,23 @@ export interface UpdateCheckResult {
   checkedAt: string;
 }
 
+export type UpdateApplyState = 'idle' | 'running' | 'succeeded' | 'failed';
+
+export interface UpdateApplyStartResult {
+  operationId: string;
+  startedAt: string;
+  targetVersion?: string;
+}
+
+export interface UpdateApplyStatus {
+  state: UpdateApplyState;
+  step: string;
+  message?: string;
+  operationId?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
+
 export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive';


### PR DESCRIPTION
## Summary
- add durable runtime storage at `~/Library/Application Support/Stradl` (or `STRADL_DATA_DIR`) with one-time migration from legacy repo data files
- add backend self-update orchestration with `POST /api/update-apply` and `GET /api/update-apply-status`, including localhost + clean-tree + launch-agent preflight checks
- add macOS self-update runner script to fetch/pull/install/build/restart service and persist progress to `update-status.json`
- wire frontend update UX with `Update now` button, live apply-status polling, and post-success reload behavior
- move LaunchAgent log paths to the durable data directory and document new update/data behavior in README
- add coverage for storage migration and update-apply route behavior

## Validation
- npm test
- npm run build
