### PR TITLE
Add searchable blocker picker and task ID badges

### DIFF
--- a/scripts/install-service.js
+++ b/scripts/install-service.js
@@ -1,12 +1,20 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectDir = path.resolve(__dirname, '..');
-const plistPath = path.join(process.env.HOME, 'Library/LaunchAgents/com.stradl.server.plist');
+const homeDir = process.env.HOME || os.homedir();
+const plistPath = path.join(homeDir, 'Library/LaunchAgents/com.stradl.server.plist');
+const configuredDataDir = process.env.STRADL_DATA_DIR?.trim();
+const dataDir = configuredDataDir
+  ? path.resolve(configuredDataDir)
+  : path.join(homeDir, 'Library', 'Application Support', 'Stradl');
 const nodePath = execSync('which node').toString().trim();
+
+fs.mkdirSync(dataDir, { recursive: true });
 
 const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -26,9 +34,9 @@ const plist = `<?xml version="1.0" encoding="UTF-8"?>
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${projectDir}/data/server.log</string>
+  <string>${dataDir}/server.log</string>
   <key>StandardErrorPath</key>
-  <string>${projectDir}/data/server-error.log</string>
+  <string>${dataDir}/server-error.log</string>
 </dict>
 </plist>`;
 

--- a/scripts/self-update.js
+++ b/scripts/self-update.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      parsed[key] = 'true';
+      continue;
+    }
+    parsed[key] = value;
+    i += 1;
+  }
+  return parsed;
+}
+
+function formatCommandError(error) {
+  if (!error || typeof error !== 'object') {
+    return 'Command failed.';
+  }
+
+  const maybeError = error;
+  const stderr = typeof maybeError.stderr === 'string'
+    ? maybeError.stderr.trim()
+    : Buffer.isBuffer(maybeError.stderr)
+      ? maybeError.stderr.toString('utf-8').trim()
+      : '';
+  if (stderr) return stderr;
+
+  const stdout = typeof maybeError.stdout === 'string'
+    ? maybeError.stdout.trim()
+    : Buffer.isBuffer(maybeError.stdout)
+      ? maybeError.stdout.toString('utf-8').trim()
+      : '';
+  if (stdout) return stdout;
+
+  if (maybeError instanceof Error && maybeError.message) {
+    return maybeError.message;
+  }
+  return 'Command failed.';
+}
+
+function readLocalVersion(projectRoot) {
+  const packagePath = path.join(projectRoot, 'package.json');
+  const raw = fs.readFileSync(packagePath, 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (!parsed.version || typeof parsed.version !== 'string') {
+    throw new Error('App version missing.');
+  }
+  return parsed.version.replace(/^v/i, '').trim();
+}
+
+function runCommand(command, cwd) {
+  try {
+    execSync(command, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+  } catch (error) {
+    throw new Error(formatCommandError(error));
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const statusFile = args['status-file'];
+const operationId = args['operation-id'];
+const startedAt = args['started-at'] || new Date().toISOString();
+const projectRoot = process.cwd();
+
+if (!statusFile || !operationId) {
+  console.error('Usage: node scripts/self-update.js --status-file <path> --operation-id <id> [--started-at <iso>] [--from-version <ver>]');
+  process.exit(1);
+}
+
+const state = {
+  state: 'running',
+  step: 'starting',
+  operationId,
+  startedAt,
+  fromVersion: typeof args['from-version'] === 'string' ? args['from-version'] : undefined,
+  toVersion: undefined,
+  message: 'Starting self-update.',
+  finishedAt: undefined,
+};
+
+function writeStatus() {
+  fs.mkdirSync(path.dirname(statusFile), { recursive: true });
+  fs.writeFileSync(statusFile, JSON.stringify(state, null, 2));
+}
+
+function setStep(step, message) {
+  state.state = 'running';
+  state.step = step;
+  state.message = message;
+  writeStatus();
+}
+
+function markFailed(message) {
+  state.state = 'failed';
+  state.message = message;
+  state.finishedAt = new Date().toISOString();
+  writeStatus();
+}
+
+function markSucceeded() {
+  state.state = 'succeeded';
+  state.step = 'completed';
+  state.message = 'Update applied successfully.';
+  state.finishedAt = new Date().toISOString();
+  writeStatus();
+}
+
+try {
+  if (!state.fromVersion) {
+    state.fromVersion = readLocalVersion(projectRoot);
+  }
+  writeStatus();
+
+  setStep('fetching', 'Fetching latest origin/main.');
+  runCommand('git fetch origin main', projectRoot);
+
+  setStep('pulling', 'Pulling latest origin/main.');
+  runCommand('git pull --ff-only origin main', projectRoot);
+
+  setStep('installing-dependencies', 'Installing dependencies.');
+  runCommand('npm ci --include=dev', projectRoot);
+
+  setStep('building', 'Building application.');
+  runCommand('npm run build', projectRoot);
+
+  state.toVersion = readLocalVersion(projectRoot);
+
+  const uid = typeof process.getuid === 'function'
+    ? String(process.getuid())
+    : process.env.UID;
+  if (!uid) {
+    throw new Error('Unable to determine user id for launchctl.');
+  }
+
+  setStep('restarting', 'Restarting LaunchAgent service.');
+  runCommand(`launchctl kickstart -k gui/${uid}/com.stradl.server`, projectRoot);
+
+  markSucceeded();
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'Self-update failed.';
+  markFailed(message);
+  process.exit(1);
+}

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readDataFromPaths, resolveStoragePaths } from '../storage.js';
+
+function makeAppData(title: string) {
+  const now = '2026-02-24T00:00:00.000Z';
+  return {
+    tasks: [
+      {
+        id: 1,
+        title,
+        status: '',
+        priority: 'P1',
+        createdAt: now,
+        updatedAt: now,
+        completedAt: null,
+        isArchived: false,
+      },
+    ],
+    blockers: [],
+    settings: {
+      staleThresholdHours: 48,
+      topN: 20,
+      oneTimeOffsetHours: 0,
+      oneTimeOffsetExpiresAt: null,
+      vacationPromptLastShownForUpdatedAt: null,
+    },
+    nextTaskId: 2,
+    nextBlockerId: 1,
+  };
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+const tempRoots: string[] = [];
+
+function createProjectPaths() {
+  const projectRoot = fs.mkdtempSync(path.join(process.cwd(), 'tmp-storage-'));
+  const homeDir = fs.mkdtempSync(path.join(process.cwd(), 'tmp-storage-home-'));
+  tempRoots.push(projectRoot, homeDir);
+
+  const paths = resolveStoragePaths({
+    projectRoot,
+    platform: 'darwin',
+    homeDir,
+    env: {},
+  });
+
+  return { projectRoot, paths };
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0, tempRoots.length)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('storage migration pathing', () => {
+  it('migrates from project data/tasks.json when destination does not exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(path.join(projectRoot, 'data', 'tasks.json'), makeAppData('from-project-data'));
+
+    const data = readDataFromPaths(paths);
+
+    expect(data.tasks[0].title).toBe('from-project-data');
+    expect(fs.existsSync(paths.dataFile)).toBe(true);
+  });
+
+  it('migrates from project server/data/tasks.json when destination does not exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(path.join(projectRoot, 'server', 'data', 'tasks.json'), makeAppData('from-server-data'));
+
+    const data = readDataFromPaths(paths);
+
+    expect(data.tasks[0].title).toBe('from-server-data');
+    expect(fs.existsSync(paths.dataFile)).toBe(true);
+  });
+
+  it('prefers the newest legacy file when both legacy locations exist', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    const legacyProjectData = path.join(projectRoot, 'data', 'tasks.json');
+    const legacyServerData = path.join(projectRoot, 'server', 'data', 'tasks.json');
+
+    writeJson(legacyProjectData, makeAppData('older-source'));
+    writeJson(legacyServerData, makeAppData('newer-source'));
+    const now = new Date();
+    const older = new Date(now.getTime() - 60_000);
+    fs.utimesSync(legacyProjectData, older, older);
+    fs.utimesSync(legacyServerData, now, now);
+
+    const data = readDataFromPaths(paths);
+    expect(data.tasks[0].title).toBe('newer-source');
+  });
+
+  it('does not overwrite existing app-support data file', () => {
+    const { projectRoot, paths } = createProjectPaths();
+    writeJson(paths.dataFile, makeAppData('existing-target'));
+    writeJson(path.join(projectRoot, 'data', 'tasks.json'), makeAppData('legacy-source'));
+
+    const data = readDataFromPaths(paths);
+    expect(data.tasks[0].title).toBe('existing-target');
+  });
+});

--- a/server/routes/update.ts
+++ b/server/routes/update.ts
@@ -1,7 +1,9 @@
+import * as childProcess from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import type { Request } from 'express';
 import { Router } from 'express';
+import { findProjectRoot, getDataDirectory } from '../storage.js';
 
 interface GitHubRelease {
   tag_name: string;
@@ -10,23 +12,39 @@ interface GitHubRelease {
   name?: string;
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export type UpdateApplyState = 'idle' | 'running' | 'succeeded' | 'failed';
 
-function findProjectRoot(): string {
-  const candidates = [
-    path.resolve(__dirname, '../../..'),
-    path.resolve(__dirname, '../..'),
-  ];
+interface UpdateApplyStatus {
+  state: UpdateApplyState;
+  step: string;
+  message?: string;
+  operationId?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
 
-  const resolved = candidates.find((candidate) =>
-    fs.existsSync(path.join(candidate, 'package.json'))
-  );
+interface UpdateApplyStartResponse {
+  operationId: string;
+  startedAt: string;
+  targetVersion?: string;
+}
 
-  if (!resolved) {
-    throw new Error('Project root not found.');
+const SELF_UPDATE_FLAG = 'STRADL_ENABLE_SELF_UPDATE';
+const UPDATE_STATUS_FILE = 'update-status.json';
+const LAUNCH_AGENT_LABEL = 'com.stradl.server';
+const PROJECT_ROOT = findProjectRoot();
+
+let updateInFlight = false;
+
+class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
   }
-
-  return resolved;
 }
 
 function normalizeVersion(value: string): string {
@@ -52,7 +70,7 @@ function isVersionNewer(latest: string, current: string): boolean {
 }
 
 function readCurrentVersion(): string {
-  const packagePath = path.join(findProjectRoot(), 'package.json');
+  const packagePath = path.join(PROJECT_ROOT, 'package.json');
   const raw = fs.readFileSync(packagePath, 'utf-8');
   const parsed = JSON.parse(raw) as { version?: string };
 
@@ -61,6 +79,142 @@ function readCurrentVersion(): string {
   }
 
   return normalizeVersion(parsed.version);
+}
+
+export function isSelfUpdateEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[SELF_UPDATE_FLAG] === 'true';
+}
+
+export function isLoopbackAddress(address: string | undefined | null): boolean {
+  if (!address) return false;
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+function isLocalRequest(req: Request): boolean {
+  return isLoopbackAddress(req.ip) || isLoopbackAddress(req.socket.remoteAddress);
+}
+
+function runCapture(command: string, cwd: string): string {
+  return childProcess.execSync(command, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function getLaunchAgentPath(): string {
+  const home = process.env.HOME;
+  if (!home) {
+    throw new HttpError(400, 'HOME is not set; cannot verify LaunchAgent installation.');
+  }
+  return path.join(home, 'Library', 'LaunchAgents', `${LAUNCH_AGENT_LABEL}.plist`);
+}
+
+function ensureLaunchAgentInstalled(): void {
+  const launchAgentPath = getLaunchAgentPath();
+  if (!fs.existsSync(launchAgentPath)) {
+    throw new HttpError(
+      400,
+      `LaunchAgent is not installed (${launchAgentPath}). Run npm run install-service first.`
+    );
+  }
+}
+
+function ensureCleanWorkingTree(projectRoot: string): void {
+  let statusOutput: string;
+  try {
+    statusOutput = runCapture('git status --porcelain', projectRoot);
+  } catch {
+    throw new HttpError(500, 'Failed to inspect git working tree.');
+  }
+
+  if (statusOutput) {
+    throw new HttpError(
+      409,
+      'Update blocked: working tree has local changes. Commit or stash changes before updating.'
+    );
+  }
+}
+
+function getUpdateStatusPath(): string {
+  return path.join(getDataDirectory(), UPDATE_STATUS_FILE);
+}
+
+function writeUpdateApplyStatus(status: UpdateApplyStatus): void {
+  const statusPath = getUpdateStatusPath();
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
+}
+
+function readUpdateApplyStatus(): UpdateApplyStatus {
+  const statusPath = getUpdateStatusPath();
+  if (!fs.existsSync(statusPath)) {
+    updateInFlight = false;
+    return { state: 'idle', step: 'idle' };
+  }
+
+  try {
+    const raw = fs.readFileSync(statusPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<UpdateApplyStatus>;
+    if (
+      parsed.state !== 'idle' &&
+      parsed.state !== 'running' &&
+      parsed.state !== 'succeeded' &&
+      parsed.state !== 'failed'
+    ) {
+      return { state: 'idle', step: 'idle' };
+    }
+
+    const step = typeof parsed.step === 'string' ? parsed.step : 'idle';
+    const status: UpdateApplyStatus = {
+      state: parsed.state,
+      step,
+      message: typeof parsed.message === 'string' ? parsed.message : undefined,
+      operationId: typeof parsed.operationId === 'string' ? parsed.operationId : undefined,
+      startedAt: typeof parsed.startedAt === 'string' ? parsed.startedAt : undefined,
+      finishedAt: typeof parsed.finishedAt === 'string' ? parsed.finishedAt : undefined,
+      fromVersion: typeof parsed.fromVersion === 'string' ? parsed.fromVersion : undefined,
+      toVersion: typeof parsed.toVersion === 'string' ? parsed.toVersion : undefined,
+    };
+
+    if (status.state !== 'running') {
+      updateInFlight = false;
+    }
+
+    return status;
+  } catch {
+    return { state: 'idle', step: 'idle' };
+  }
+}
+
+function spawnSelfUpdateProcess(args: {
+  operationId: string;
+  startedAt: string;
+  fromVersion: string;
+}): void {
+  const statusPath = getUpdateStatusPath();
+  const scriptPath = path.join(PROJECT_ROOT, 'scripts', 'self-update.js');
+
+  if (!fs.existsSync(scriptPath)) {
+    throw new HttpError(500, `Self-update script missing: ${scriptPath}`);
+  }
+
+  const child = childProcess.spawn(
+    process.execPath,
+    [
+      scriptPath,
+      '--status-file', statusPath,
+      '--operation-id', args.operationId,
+      '--started-at', args.startedAt,
+      '--from-version', args.fromVersion,
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      detached: true,
+      stdio: 'ignore',
+    }
+  );
+  child.unref();
 }
 
 export const updateRoutes = Router();
@@ -138,4 +292,71 @@ updateRoutes.get('/update-check', async (_req, res) => {
     publishedAt: release.published_at,
     checkedAt,
   });
+});
+
+updateRoutes.post('/update-apply', (req, res) => {
+  let statusInitialized = false;
+  try {
+    if (!isSelfUpdateEnabled()) {
+      throw new HttpError(403, `Self-update is disabled. Set ${SELF_UPDATE_FLAG}=true to enable.`);
+    }
+
+    if (!isLocalRequest(req)) {
+      throw new HttpError(403, 'Self-update is only allowed from localhost.');
+    }
+
+    const existingStatus = readUpdateApplyStatus();
+    if (updateInFlight || existingStatus.state === 'running') {
+      throw new HttpError(409, 'An update is already running.');
+    }
+
+    ensureLaunchAgentInstalled();
+    ensureCleanWorkingTree(PROJECT_ROOT);
+
+    let fromVersion: string;
+    try {
+      fromVersion = readCurrentVersion();
+    } catch {
+      throw new HttpError(500, 'Failed to read local app version.');
+    }
+
+    const operationId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const startedAt = new Date().toISOString();
+    writeUpdateApplyStatus({
+      state: 'running',
+      step: 'queued',
+      message: 'Update queued.',
+      operationId,
+      startedAt,
+      fromVersion,
+    });
+    statusInitialized = true;
+
+    spawnSelfUpdateProcess({ operationId, startedAt, fromVersion });
+    updateInFlight = true;
+
+    const payload: UpdateApplyStartResponse = { operationId, startedAt };
+    res.status(202).json(payload);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to start update.';
+    if (statusInitialized) {
+      writeUpdateApplyStatus({
+        state: 'failed',
+        step: 'start',
+        message,
+        finishedAt: new Date().toISOString(),
+      });
+    }
+    updateInFlight = false;
+
+    if (error instanceof HttpError) {
+      res.status(error.status).send(message);
+      return;
+    }
+    res.status(500).send(message);
+  }
+});
+
+updateRoutes.get('/update-apply-status', (_req, res) => {
+  res.json(readUpdateApplyStatus());
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,12 @@
-import type { Task, Blocker, Settings, TabName, UpdateCheckResult } from './types';
+import type {
+  Task,
+  Blocker,
+  Settings,
+  TabName,
+  UpdateCheckResult,
+  UpdateApplyStartResult,
+  UpdateApplyStatus,
+} from './types';
 
 const BASE = '/api';
 
@@ -56,3 +64,9 @@ export const updateSettings = (data: Partial<Settings>) =>
 // Updates
 export const checkForUpdates = () =>
   request<UpdateCheckResult>('/update-check');
+
+export const applyUpdate = () =>
+  request<UpdateApplyStartResult>('/update-apply', { method: 'POST' });
+
+export const fetchUpdateApplyStatus = () =>
+  request<UpdateApplyStatus>('/update-apply-status');

--- a/src/components/BlockerForm.tsx
+++ b/src/components/BlockerForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { Task } from '../types';
 
 interface Props {
@@ -8,19 +8,173 @@ interface Props {
   onAdd: (data: { blockedByTaskId?: number; blockedUntilDate?: string }) => Promise<void>;
 }
 
+const PRIORITY_RANK: Record<NonNullable<Task['priority']>, number> = {
+  P0: 0,
+  P1: 1,
+  P2: 2,
+};
+
+function parseTaskIdInput(value: string): number | null {
+  const match = value.trim().match(/^#?(\d+)$/);
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+function compareTasks(a: Task, b: Task): number {
+  const aPriorityRank = a.priority ? PRIORITY_RANK[a.priority] : 3;
+  const bPriorityRank = b.priority ? PRIORITY_RANK[b.priority] : 3;
+  if (aPriorityRank !== bPriorityRank) return aPriorityRank - bPriorityRank;
+
+  const aUpdated = new Date(a.updatedAt).getTime();
+  const bUpdated = new Date(b.updatedAt).getTime();
+  if (aUpdated !== bUpdated) {
+    const normalizedA = Number.isNaN(aUpdated) ? 0 : aUpdated;
+    const normalizedB = Number.isNaN(bUpdated) ? 0 : bUpdated;
+    if (normalizedA !== normalizedB) return normalizedB - normalizedA;
+  }
+
+  return a.id - b.id;
+}
+
 export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAdd }: Props) {
   const [blockerType, setBlockerType] = useState<'task' | 'date' | 'duration'>('task');
-  const [selectedTask, setSelectedTask] = useState<string>('');
+  const [taskQuery, setTaskQuery] = useState('');
+  const [showTaskResults, setShowTaskResults] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [taskError, setTaskError] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState('');
 
-  const otherTasks = allTasks.filter(
-    t => t.id !== taskId && t.completedAt == null && !t.isArchived
-  );
+  const allTasksById = useMemo(() => {
+    return new Map(allTasks.map(t => [t.id, t]));
+  }, [allTasks]);
+
+  const candidateTasks = useMemo(() => {
+    return allTasks.filter(t => t.id !== taskId && t.completedAt == null && !t.isArchived);
+  }, [allTasks, taskId]);
+
+  const parsedTaskId = useMemo(() => parseTaskIdInput(taskQuery), [taskQuery]);
+
+  const typedTaskError = useMemo(() => {
+    if (parsedTaskId == null) return null;
+
+    const typedTask = allTasksById.get(parsedTaskId);
+    if (!typedTask) return `No task found with ID #${parsedTaskId}.`;
+    if (typedTask.id === taskId) return 'A task cannot be blocked by itself.';
+    if (typedTask.isArchived) return `Task #${parsedTaskId} cannot be used because it is archived.`;
+    if (typedTask.completedAt != null) return `Task #${parsedTaskId} cannot be used because it is completed.`;
+
+    return null;
+  }, [allTasksById, parsedTaskId, taskId]);
+
+  const rankedMatches = useMemo(() => {
+    const trimmedQuery = taskQuery.trim();
+    if (!trimmedQuery) {
+      return [...candidateTasks].sort(compareTasks);
+    }
+
+    const query = trimmedQuery.toLowerCase();
+    const idQueryMatch = trimmedQuery.match(/^#?(\d+)$/);
+    const idQuery = idQueryMatch ? idQueryMatch[1] : null;
+
+    const scored = candidateTasks
+      .map((task) => {
+        const id = String(task.id);
+        const title = task.title.toLowerCase();
+
+        if (idQuery && id === idQuery) {
+          return { task, bucket: 0 };
+        }
+        if (idQuery && id.startsWith(idQuery)) {
+          return { task, bucket: 1 };
+        }
+        if (title.startsWith(query)) {
+          return { task, bucket: 2 };
+        }
+        if (title.includes(query)) {
+          return { task, bucket: 3 };
+        }
+        return null;
+      })
+      .filter((item): item is { task: Task; bucket: number } => item != null);
+
+    scored.sort((a, b) => {
+      if (a.bucket !== b.bucket) return a.bucket - b.bucket;
+      return compareTasks(a.task, b.task);
+    });
+
+    return scored.map(item => item.task);
+  }, [candidateTasks, taskQuery]);
+
+  const visibleMatches = rankedMatches.slice(0, 8);
+  const resultsListId = `blocker-task-results-${taskId}`;
+  const activeDescendantId = visibleMatches.length > 0
+    ? `${resultsListId}-option-${visibleMatches[Math.min(highlightedIndex, visibleMatches.length - 1)].id}`
+    : undefined;
+
+  const inlineTaskError = taskError ?? typedTaskError;
+  const canSubmitTask = useMemo(() => {
+    const trimmed = taskQuery.trim();
+    if (!trimmed) return false;
+    if (parsedTaskId != null) return typedTaskError == null;
+    return visibleMatches.length > 0;
+  }, [taskQuery, parsedTaskId, typedTaskError, visibleMatches]);
+
+  const resetTaskPicker = () => {
+    setTaskQuery('');
+    setTaskError(null);
+    setShowTaskResults(false);
+    setHighlightedIndex(0);
+  };
+
+  const addTaskById = async (candidateTaskId: number): Promise<boolean> => {
+    const candidateTask = allTasksById.get(candidateTaskId);
+    if (!candidateTask) {
+      setTaskError(`No task found with ID #${candidateTaskId}.`);
+      return false;
+    }
+    if (candidateTask.id === taskId) {
+      setTaskError('A task cannot be blocked by itself.');
+      return false;
+    }
+    if (candidateTask.isArchived) {
+      setTaskError(`Task #${candidateTaskId} cannot be used because it is archived.`);
+      return false;
+    }
+    if (candidateTask.completedAt != null) {
+      setTaskError(`Task #${candidateTaskId} cannot be used because it is completed.`);
+      return false;
+    }
+
+    await onAdd({ blockedByTaskId: candidateTaskId });
+    resetTaskPicker();
+    return true;
+  };
+
+  const handleTaskAdd = async () => {
+    const trimmed = taskQuery.trim();
+    if (!trimmed) {
+      setTaskError('Type a task title or #ID.');
+      return;
+    }
+
+    const directTaskId = parseTaskIdInput(trimmed);
+    if (directTaskId != null) {
+      await addTaskById(directTaskId);
+      return;
+    }
+
+    const taskToAdd = visibleMatches[highlightedIndex] ?? visibleMatches[0];
+    if (!taskToAdd) {
+      setTaskError('No matching task. Try a different title or #ID.');
+      return;
+    }
+
+    await addTaskById(taskToAdd.id);
+  };
 
   const handleAdd = async () => {
-    if (blockerType === 'task' && selectedTask) {
-      await onAdd({ blockedByTaskId: parseInt(selectedTask) });
-      setSelectedTask('');
+    if (blockerType === 'task') {
+      await handleTaskAdd();
     } else if (blockerType === 'date' && selectedDate) {
       const localEndOfDay = new Date(`${selectedDate}T23:59:59.999`);
       await onAdd({ blockedUntilDate: localEndOfDay.toISOString() });
@@ -35,19 +189,101 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
 
   return (
     <div className="blocker-form">
-      <select value={blockerType} onChange={e => setBlockerType(e.target.value as 'task' | 'date' | 'duration')} aria-label="Blocker type" disabled={isDisabled}>
+      <select
+        value={blockerType}
+        onChange={e => {
+          const nextType = e.target.value as 'task' | 'date' | 'duration';
+          setBlockerType(nextType);
+          setTaskError(null);
+          if (nextType !== 'task') resetTaskPicker();
+        }}
+        aria-label="Blocker type"
+        disabled={isDisabled}
+      >
         <option value="task">Blocked by task</option>
         <option value="date">Blocked until date</option>
         <option value="duration">Blocked for duration</option>
       </select>
 
       {blockerType === 'task' ? (
-        <select value={selectedTask} onChange={e => setSelectedTask(e.target.value)} aria-label="Blocking task" disabled={isDisabled}>
-          <option value="">Select task...</option>
-          {otherTasks.map(t => (
-            <option key={t.id} value={t.id}>{t.title}</option>
-          ))}
-        </select>
+        <div className="blocker-task-picker">
+          <input
+            value={taskQuery}
+            onChange={e => {
+              setTaskQuery(e.target.value);
+              setTaskError(null);
+              setShowTaskResults(true);
+              setHighlightedIndex(0);
+            }}
+            onFocus={() => {
+              setShowTaskResults(true);
+              if (visibleMatches.length > 0) setHighlightedIndex(0);
+            }}
+            onBlur={() => setShowTaskResults(false)}
+            onKeyDown={e => {
+              if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setShowTaskResults(true);
+                setHighlightedIndex((prev) => {
+                  if (visibleMatches.length === 0) return 0;
+                  return (prev + 1) % visibleMatches.length;
+                });
+                return;
+              }
+              if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setShowTaskResults(true);
+                setHighlightedIndex((prev) => {
+                  if (visibleMatches.length === 0) return 0;
+                  return (prev - 1 + visibleMatches.length) % visibleMatches.length;
+                });
+                return;
+              }
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                if (!isDisabled) {
+                  void handleTaskAdd();
+                }
+                return;
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setShowTaskResults(false);
+              }
+            }}
+            className="blocker-task-input"
+            placeholder="Type task title or #ID"
+            role="combobox"
+            aria-expanded={showTaskResults && visibleMatches.length > 0}
+            aria-controls={resultsListId}
+            aria-activedescendant={showTaskResults && visibleMatches.length > 0 ? activeDescendantId : undefined}
+            aria-label="Blocking task"
+            disabled={isDisabled}
+          />
+          {showTaskResults && visibleMatches.length > 0 && (
+            <ul className="blocker-task-results" id={resultsListId} role="listbox">
+              {visibleMatches.map((task, index) => (
+                <li
+                  key={task.id}
+                  id={`${resultsListId}-option-${task.id}`}
+                  role="option"
+                  aria-selected={index === highlightedIndex}
+                  className={`blocker-task-option ${index === highlightedIndex ? 'blocker-task-option-active' : ''}`}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  onMouseDown={e => e.preventDefault()}
+                  onClick={() => {
+                    if (isDisabled) return;
+                    void addTaskById(task.id);
+                  }}
+                >
+                  <span>{task.title}</span>
+                  <span className="blocker-task-meta">#{task.id} · {task.priority ?? 'Idea'}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {inlineTaskError && <div className="blocker-task-error">{inlineTaskError}</div>}
+        </div>
       ) : blockerType === 'date' ? (
         <input
           type="date"
@@ -67,7 +303,11 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
       )}
 
       {blockerType !== 'duration' && (
-        <button className="btn btn-sm btn-primary" onClick={handleAdd} disabled={isDisabled || (blockerType === 'task' && !selectedTask) || (blockerType === 'date' && !selectedDate)}>
+        <button
+          className="btn btn-sm btn-primary"
+          onClick={handleAdd}
+          disabled={isDisabled || (blockerType === 'task' && !canSubmitTask) || (blockerType === 'date' && !selectedDate)}
+        >
           Add Blocker
         </button>
       )}

--- a/src/components/BlockerList.tsx
+++ b/src/components/BlockerList.tsx
@@ -35,7 +35,9 @@ export default function BlockerList({ blockers, allTasks, onRemove, isDisabled =
           <div key={b.id} className="blocker-item">
             <span>
               {blockingTask
-                ? `Blocked by: ${blockingTask.title}`
+                ? `Blocked by: #${blockingTask.id} · ${blockingTask.title}`
+                : b.blockedByTaskId
+                  ? `Blocked by: #${b.blockedByTaskId} (task not found)`
                 : b.blockedUntilDate
                   ? formatBlockedUntil(b.blockedUntilDate)
                   : 'Unknown blocker'}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -200,7 +200,10 @@ export default function TaskRow({
               disabled={isPending}
             />
           ) : (
-            <span>{task.title}</span>
+            <span className="task-title-display">
+              <span className="task-id-badge">#{task.id}</span>
+              <span className="task-title-text">{task.title}</span>
+            </span>
           )}
         </div>
 

--- a/src/hooks/useApplyUpdate.ts
+++ b/src/hooks/useApplyUpdate.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { UpdateApplyStatus } from '../types';
+import * as api from '../api';
+
+const POLL_INTERVAL_MS = 2000;
+
+function getMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return 'Failed to process update request.';
+}
+
+interface RefreshOptions {
+  suppressError?: boolean;
+}
+
+export function useApplyUpdate() {
+  const [status, setStatus] = useState<UpdateApplyStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshStatus = useCallback(async (options?: RefreshOptions) => {
+    const suppressError = options?.suppressError ?? false;
+    try {
+      const next = await api.fetchUpdateApplyStatus();
+      setStatus(next);
+      setError(null);
+      return next;
+    } catch (err) {
+      if (!suppressError) {
+        setError(getMessage(err));
+      }
+      throw err;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status?.state !== 'running') return;
+
+    const timer = window.setInterval(() => {
+      void refreshStatus({ suppressError: true });
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refreshStatus, status?.state]);
+
+  const applyNow = useCallback(async () => {
+    setError(null);
+    try {
+      const started = await api.applyUpdate();
+      setStatus({
+        state: 'running',
+        step: 'queued',
+        operationId: started.operationId,
+        startedAt: started.startedAt,
+        toVersion: started.targetVersion,
+      });
+      await refreshStatus({ suppressError: true });
+    } catch (error) {
+      const message = getMessage(error);
+      setError(message);
+      throw new Error(message);
+    }
+  }, [refreshStatus]);
+
+  return {
+    status,
+    error,
+    isApplying: status?.state === 'running',
+    applyNow,
+    refreshStatus,
+  };
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -607,6 +607,15 @@ textarea:focus-visible,
   margin-top: 0.25rem;
 }
 
+.settings-update-progress {
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+}
+
+.settings-update-message {
+  margin-top: -0.25rem;
+}
+
 /* Dark Mode Toggle */
 .theme-toggle {
   border: none;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -359,11 +359,30 @@ textarea:focus-visible,
   min-width: 0;
 }
 
-.task-title span {
+.task-title-display {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.task-id-badge {
+  flex-shrink: 0;
+  border: 1px solid var(--border-default);
+  border-radius: 999px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  background: var(--bg-input);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+.task-title-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   display: block;
+  min-width: 0;
 }
 
 /* Status section - full width below title row */
@@ -500,6 +519,16 @@ textarea:focus-visible,
   align-items: center;
 }
 
+.blocker-task-picker {
+  position: relative;
+  min-width: 260px;
+  flex: 1;
+}
+
+.blocker-task-input {
+  width: 100%;
+}
+
 .blocker-form select,
 .blocker-form input {
   padding: 0.25rem 0.375rem;
@@ -508,6 +537,50 @@ textarea:focus-visible,
   font-size: 0.8125rem;
   background: var(--bg-input);
   color: var(--text-primary);
+}
+
+.blocker-task-results {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  z-index: 20;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-light);
+  border-radius: 0.375rem;
+  box-shadow: 0 6px 16px var(--shadow-sm);
+  max-height: 220px;
+  overflow: auto;
+}
+
+.blocker-task-option {
+  min-height: 36px;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.125rem;
+}
+
+.blocker-task-option:hover,
+.blocker-task-option-active {
+  background: var(--blocker-bg);
+}
+
+.blocker-task-meta {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}
+
+.blocker-task-error {
+  font-size: 0.75rem;
+  color: var(--red-700);
+  margin-top: 0.25rem;
 }
 
 .duration-presets {
@@ -898,7 +971,7 @@ textarea:focus-visible,
     gap: 0.5rem;
   }
 
-  .task-title span {
+  .task-title-text {
     white-space: normal;
   }
 
@@ -925,6 +998,16 @@ textarea:focus-visible,
   .blocker-form {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .blocker-task-picker {
+    min-width: 0;
+  }
+
+  .blocker-task-results {
+    position: static;
+    margin-top: 0.25rem;
+    max-height: 180px;
   }
 
   .btn,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,4 +35,23 @@ export interface UpdateCheckResult {
   checkedAt: string;
 }
 
+export type UpdateApplyState = 'idle' | 'running' | 'succeeded' | 'failed';
+
+export interface UpdateApplyStartResult {
+  operationId: string;
+  startedAt: string;
+  targetVersion?: string;
+}
+
+export interface UpdateApplyStatus {
+  state: UpdateApplyState;
+  step: string;
+  message?: string;
+  operationId?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
+
 export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'completed' | 'archive';


### PR DESCRIPTION
Summary
- Surface task IDs via compact badges to make blockers discoverable while keeping existing editing flows intact.
- Replace the blocker dropdown with an accessible, keyboard-friendly combobox that ranks matches by ID/title and validates invalid/blocked targets.
- Surface task IDs in blocker lists and add supporting styles so the new picker and badges stay readable across breakpoints.

Testing
- Not run (not requested)