### PR TITLE
Add CODEOWNERS to require maintainer code-owner review

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership: all files require review from the maintainer.
+* @svakili

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Report a reproducible bug in Stradl
+title: "[Bug]: "
+labels:
+  - type:bug
+  - needs-repro
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please provide enough context to reproduce.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior.
+      placeholder: A clear and concise summary.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact steps and data needed.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS and Node.js version.
+      placeholder: macOS 14.3, Node 20.11.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant error output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and usage questions
+    url: https://github.com/svakili/stradl/blob/main/SUPPORT.md
+    about: Read support guidance before opening an issue.
+  - name: Security vulnerability reporting
+    url: https://github.com/svakili/stradl/blob/main/SECURITY.md
+    about: Report vulnerabilities privately per the security policy.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,28 @@
+name: Documentation improvement
+description: Suggest improvements to docs or contributor guidance
+title: "[Docs]: "
+labels:
+  - type:docs
+body:
+  - type: textarea
+    id: issue
+    attributes:
+      label: What documentation needs improvement?
+      description: Describe what is missing, unclear, or incorrect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested change
+      description: Share your proposed wording or structure.
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Relevant file(s)
+      description: Which files are affected?
+      placeholder: README.md, CONTRIBUTING.md

--- a/.github/ISSUE_TEMPLATE/small-fix.yml
+++ b/.github/ISSUE_TEMPLATE/small-fix.yml
@@ -1,0 +1,33 @@
+name: Small fix proposal
+description: Propose a small bug fix or small UX polish change
+title: "[Small Fix]: "
+labels:
+  - scope:small-fix
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Stradl currently accepts docs and small-fix contributions.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user-visible issue does this fix?
+    validations:
+      required: true
+
+  - type: textarea
+    id: change
+    attributes:
+      label: Proposed solution
+      description: Keep the scope narrow and implementation-focused.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: What will this proposal explicitly not change?
+      placeholder: No refactors, no new feature scope.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+- 
+
+## Scope
+
+- [ ] Docs only
+- [ ] Small bug fix
+- [ ] Small UX polish
+- [ ] Small test update for existing behavior
+
+## Validation
+
+- [ ] `npm run build`
+- [ ] `npm test`
+
+## Risk Notes
+
+- User impact:
+- Rollback approach:
+
+## Related Issues
+
+- Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: test (${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders through the repository owner profile:
+https://github.com/svakili
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Stradl
+
+Thanks for your interest in contributing.
+
+## Project status and initial contribution scope
+
+Stradl is early-stage and currently accepts:
+- Documentation updates
+- Small bug fixes
+- Small UX polish fixes
+- Small tests for existing behavior
+
+For now, the following are out of scope unless explicitly requested by a maintainer:
+- New major features
+- Large refactors
+- Architectural rewrites
+- Release process changes
+
+## Development setup
+
+### Prerequisites
+- Node.js 18+
+- npm
+
+### Run locally
+```bash
+npm install
+npm run dev
+```
+
+The API runs on `http://localhost:3001` and the frontend dev server runs on `http://localhost:5173`.
+
+## Validation before opening a PR
+
+Run these commands before submitting:
+
+```bash
+npm run build
+npm test
+```
+
+Or run:
+
+```bash
+npm run verify
+```
+
+## Branch, commit, and PR conventions
+
+- Branch from `main`
+- Use a short branch name like `docs/update-readme` or `fix/task-stale-label`
+- Keep PRs focused and small
+- Include test evidence in PR description (`npm run build` and `npm test` output summary)
+- Link related issue(s) when applicable
+
+## Pull request review expectations
+
+- Maintainer first response target: within 3 business days
+- Reviews focus on behavior, risk, and maintainability
+- Maintainers may ask to split oversized PRs
+
+## Platform support for contributors
+
+Contributor workflow is cross-platform (macOS, Linux, Windows with a standard Node environment).
+
+Operational runtime features are macOS-only:
+- LaunchAgent auto-start scripts
+- One-click self-update flow that restarts via `launchctl`
+
+## Reporting bugs and requesting support
+
+- Bug reports: use GitHub Issues
+- Support and usage questions: see [SUPPORT.md](./SUPPORT.md)
+- Security vulnerabilities: see [SECURITY.md](./SECURITY.md)
+
+## Maintainer setup checklist (GitHub)
+
+After publishing this repository, configure:
+
+1. Branch protection for `main`
+   - Require pull requests before merging
+   - Require status checks to pass (`CI / test (18)`, `CI / test (20)`)
+   - Dismiss stale pull request approvals when new commits are pushed
+2. Label taxonomy
+   - `type:bug`
+   - `type:docs`
+   - `good first issue`
+   - `help wanted`
+   - `needs-repro`
+   - `scope:small-fix`

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Soheyl Vakili
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Stradl
 
+[![CI](https://github.com/svakili/stradl/actions/workflows/ci.yml/badge.svg)](https://github.com/svakili/stradl/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
 A single-user local task management web app for multitasking. Tracks tasks with priorities (P0/P1/P2/Ideas), free-text statuses, blocking relationships, and staleness indicators. Installable as a PWA.
+
+> Project status: early-stage. Current contribution scope is intentionally narrow to docs and small fixes. See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Prerequisites
 
@@ -14,6 +19,13 @@ npm run dev
 ```
 
 This starts the Express API server on port 3001 and the Vite dev server on port 5173 with hot module replacement. Open http://localhost:5173.
+
+## Platform Support
+
+- Development workflow: cross-platform (macOS, Linux, Windows with Node 18+)
+- Runtime operational extras: macOS-only
+  - LaunchAgent auto-start scripts
+  - In-app self-update flow that restarts via `launchctl`
 
 ## Production
 
@@ -44,8 +56,9 @@ npm run release:major
 Notes:
 - Requires `gh` authenticated (`gh auth status`)
 - Release tags are `v<version>` and match `package.json` version
+- Intended for maintainers
 
-## Auto-Start on Login (macOS)
+## Auto-Start on Login (macOS-only runtime feature)
 
 ```bash
 npm run install-service
@@ -59,7 +72,7 @@ To disable:
 npm run uninstall-service
 ```
 
-## In-App Self-Update (macOS)
+## In-App Self-Update (macOS-only runtime feature)
 
 The Settings panel can check for updates and apply the latest `origin/main` automatically.
 
@@ -98,6 +111,13 @@ If preflight checks fail, the API returns a clear error:
 - **Vacation mode** -- Add offset hours so tasks don't go stale while you're away
 - **Top N limiting** -- Only show the top N tasks in the Tasks tab
 - **PWA** -- Installable from the browser for a native app feel
+
+## Contributing
+
+- Contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Code of conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Security policy: [SECURITY.md](./SECURITY.md)
+- Support policy: [SUPPORT.md](./SUPPORT.md)
 
 ## Project Structure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Stradl currently supports security fixes for the latest `main` branch only.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately.
+
+Preferred method:
+1. Use GitHub's private vulnerability reporting flow (Security tab -> Report a vulnerability).
+2. Include clear reproduction steps, impact, and affected versions/commit SHA if known.
+
+If private vulnerability reporting is not available, contact the repository owner directly:
+- https://github.com/svakili
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+## Response Expectations
+
+- Initial triage acknowledgement: within 3 business days
+- Follow-up with status/severity: within 7 business days
+- Remediation timeline depends on impact and complexity
+
+We will coordinate disclosure timing with reporters whenever possible.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+## Where to ask for help
+
+For usage questions and troubleshooting:
+- Open a GitHub issue with context and reproduction details.
+
+For confirmed bugs:
+- Open a bug report issue and include steps to reproduce, expected behavior, and actual behavior.
+
+For security vulnerabilities:
+- Do not file a public issue.
+- Follow the process in [SECURITY.md](./SECURITY.md).
+
+## What to include in support requests
+
+- Your operating system and Node.js version
+- Commands you ran
+- Relevant logs or error output
+- Clear reproduction steps

--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "stradl",
   "version": "1.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "type": "module",
   "scripts": {
     "dev": "concurrently \"tsx watch server/index.ts\" \"vite\"",
     "build": "vite build && tsc -p tsconfig.server.json",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
+    "verify": "npm run build && npm test",
     "start": "node server/dist/index.js",
     "preview": "vite preview",
     "install-service": "node scripts/install-service.js",


### PR DESCRIPTION
## Summary
- add .github/CODEOWNERS with wildcard ownership for @svakili

## Why
- branch protection now requires code-owner review
- this makes @svakili the required reviewer for all paths

## Notes
- admins can still bypass review because enforce_admins is disabled