### PR TITLE
Add CODEOWNERS to require maintainer code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership: all files require review from the maintainer.
+* @svakili


### PR DESCRIPTION
## Summary
- add .github/CODEOWNERS with wildcard ownership for @svakili

## Why
- branch protection requires code-owner review
- this makes @svakili the required reviewer for all paths

## Notes
- admins can still bypass review because enforce_admins is disabled