### PR TITLE
Fix status blur-to-save, blocker staleness, and unblock timing

### DIFF
--- a/server/routes/blockers.ts
+++ b/server/routes/blockers.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { readData, writeData } from '../storage.js';
+import { hasUnresolvedBlockers } from '../task-logic.js';
 
 export const blockerRoutes = Router();
 
@@ -50,7 +51,17 @@ blockerRoutes.delete('/blockers/:id', (req, res) => {
     return;
   }
 
+  const taskId = data.blockers[idx].taskId;
   data.blockers.splice(idx, 1);
+
+  // If the task has no more unresolved blockers, touch updatedAt so it isn't stale
+  if (!hasUnresolvedBlockers(taskId, data)) {
+    const task = data.tasks.find(t => t.id === taskId);
+    if (task) {
+      task.updatedAt = new Date().toISOString();
+    }
+  }
+
   writeData(data);
   res.status(204).end();
 });

--- a/server/task-logic.ts
+++ b/server/task-logic.ts
@@ -5,6 +5,7 @@ export const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2 };
 export function autoUnblock(data: AppData): boolean {
   const now = new Date();
   let changed = false;
+  const newlyUnblockedTaskIds = new Set<number>();
 
   for (const blocker of data.blockers) {
     if (blocker.resolved) continue;
@@ -13,6 +14,7 @@ export function autoUnblock(data: AppData): boolean {
     if (blocker.blockedUntilDate && new Date(blocker.blockedUntilDate) <= now) {
       blocker.resolved = true;
       changed = true;
+      newlyUnblockedTaskIds.add(blocker.taskId);
     }
 
     // Task-based auto-unblock
@@ -21,6 +23,17 @@ export function autoUnblock(data: AppData): boolean {
       if (blockingTask && blockingTask.completedAt != null) {
         blocker.resolved = true;
         changed = true;
+        newlyUnblockedTaskIds.add(blocker.taskId);
+      }
+    }
+  }
+
+  // Touch updatedAt for tasks that are now fully unblocked so they aren't stale
+  for (const taskId of newlyUnblockedTaskIds) {
+    if (!hasUnresolvedBlockers(taskId, data)) {
+      const task = data.tasks.find(t => t.id === taskId);
+      if (task) {
+        task.updatedAt = now.toISOString();
       }
     }
   }

--- a/src/components/BlockerForm.tsx
+++ b/src/components/BlockerForm.tsx
@@ -176,8 +176,8 @@ export default function BlockerForm({ taskId, allTasks, isDisabled = false, onAd
     if (blockerType === 'task') {
       await handleTaskAdd();
     } else if (blockerType === 'date' && selectedDate) {
-      const localEndOfDay = new Date(`${selectedDate}T23:59:59.999`);
-      await onAdd({ blockedUntilDate: localEndOfDay.toISOString() });
+      const localStartOfDay = new Date(`${selectedDate}T00:00:00.000`);
+      await onAdd({ blockedUntilDate: localStartOfDay.toISOString() });
       setSelectedDate('');
     }
   };

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -70,6 +70,7 @@ export default function TaskRow({
   const [showBlockers, setShowBlockers] = useState(activeTab === 'blocked');
   const [showHideMenu, setShowHideMenu] = useState(false);
   const skipNextTitleBlurSaveRef = useRef(false);
+  const skipNextStatusBlurSaveRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const hideMenuRef = useRef<HTMLDivElement>(null);
 
@@ -150,6 +151,7 @@ export default function TaskRow({
   };
 
   const cancelStatusEdit = () => {
+    skipNextStatusBlurSaveRef.current = true;
     setEditingStatus(false);
     setStatusValue(task.status);
   };
@@ -367,6 +369,13 @@ export default function TaskRow({
               ref={textareaRef}
               autoFocus
               value={statusValue}
+              onBlur={() => {
+                if (skipNextStatusBlurSaveRef.current) {
+                  skipNextStatusBlurSaveRef.current = false;
+                  return;
+                }
+                void saveStatus();
+              }}
               onChange={(e) => {
                 setStatusValue(e.target.value);
                 autoResizeTextarea(e.target);


### PR DESCRIPTION
## Summary
- **Status field blur-to-save**: Clicking outside the status textarea now saves changes automatically, matching the existing title field behavior. Cancel button and Escape key still discard changes.
- **Blocker staleness fix**: When a task becomes unblocked (auto or manual), its updatedAt is refreshed so it no longer appears stale (purple) immediately after unblocking.
- **Date-based unblock timing**: Date-based blockers now unblock at the start of the selected day (midnight) instead of end-of-day (23:59:59).

## Test plan
- [ ] Edit a task status, click outside the textarea - changes should save
- [ ] Edit a task status, press Escape - changes should be discarded
- [ ] Edit a task status, click Cancel - changes should be discarded
- [ ] Block a task until a past date, reload - task should appear with normal coloring, not stale purple
- [ ] Manually remove the last blocker from a stale blocked task - task should not appear stale
- [ ] Add a date-based blocker - verify the stored timestamp uses midnight (T00:00:00)

Generated with [Claude Code](https://claude.com/claude-code)