### PR TITLE
Add hide until tomorrow and date picker to hide menu

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -230,12 +230,6 @@ taskRoutes.post('/tasks/:id/hide', (req, res) => {
     return;
   }
 
-  const durationMinutes = Number(req.body?.durationMinutes);
-  if (!Number.isInteger(durationMinutes) || !ALLOWED_HIDE_DURATIONS.has(durationMinutes)) {
-    res.status(400).json({ error: 'durationMinutes must be one of 15, 30, 60, 120, 240' });
-    return;
-  }
-
   const isActivePrioritizedTask = !task.isArchived
     && task.completedAt == null
     && task.priority != null
@@ -247,7 +241,22 @@ taskRoutes.post('/tasks/:id/hide', (req, res) => {
     return;
   }
 
-  task.hiddenUntilAt = new Date(now.getTime() + durationMinutes * 60000).toISOString();
+  const durationMinutes = Number(req.body?.durationMinutes);
+  const hideUntilDate = req.body?.hideUntilDate;
+
+  if (Number.isInteger(durationMinutes) && ALLOWED_HIDE_DURATIONS.has(durationMinutes)) {
+    task.hiddenUntilAt = new Date(now.getTime() + durationMinutes * 60000).toISOString();
+  } else if (typeof hideUntilDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(hideUntilDate)) {
+    const targetDate = new Date(hideUntilDate + 'T00:00:00');
+    if (Number.isNaN(targetDate.getTime()) || targetDate <= now) {
+      res.status(400).json({ error: 'hideUntilDate must be a valid future date (YYYY-MM-DD)' });
+      return;
+    }
+    task.hiddenUntilAt = targetDate.toISOString();
+  } else {
+    res.status(400).json({ error: 'Provide durationMinutes (15|30|60|120|240) or hideUntilDate (YYYY-MM-DD)' });
+    return;
+  }
   clearFocusForTask(data, id);
   writeData(data);
   res.json(task);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ export default function App() {
   const vacationNudgeEvaluatedRef = useRef(false);
   const handledUpdateSuccessRef = useRef<string | null>(null);
 
-  const { tasks, loading, reload, create, update, complete, uncomplete, hide, unhide, focus, clearFocus, remove } = useTasks(activeTab);
+  const { tasks, loading, reload, create, update, complete, uncomplete, hide, hideUntilDate, unhide, focus, clearFocus, remove } = useTasks(activeTab);
   const { settings, loading: settingsLoading, reload: reloadSettings, update: updateSettings } = useSettings();
   const { blockers, loadForTask, create: createBlocker, remove: removeBlocker } = useBlockers();
   const {
@@ -284,6 +284,17 @@ export default function App() {
       await hide(id, durationMinutes);
       await loadCounts();
     }, `Task hidden for ${durationLabel}.`, () => {
+      void handleUnhide(id);
+    });
+  };
+
+  const handleHideUntilDate = async (id: number, date: string) => {
+    const dateObj = new Date(date + 'T00:00:00');
+    const label = dateObj.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    await runTaskAction(id, async () => {
+      await hideUntilDate(id, date);
+      await loadCounts();
+    }, `Task hidden until ${label}.`, () => {
       void handleUnhide(id);
     });
   };
@@ -577,6 +588,7 @@ export default function App() {
         onUpdate={handleUpdate}
         onComplete={handleComplete}
         onHide={handleHide}
+        onHideUntilDate={handleHideUntilDate}
         onUnhide={handleUnhide}
         onFocusToggle={handleFocusToggle}
         onUncomplete={handleUncomplete}

--- a/src/api.ts
+++ b/src/api.ts
@@ -44,6 +44,9 @@ export const uncompleteTask = (id: number) =>
 export const hideTask = (id: number, durationMinutes: 15 | 30 | 60 | 120 | 240) =>
   request<Task>(`/tasks/${id}/hide`, { method: 'POST', body: JSON.stringify({ durationMinutes }) });
 
+export const hideTaskUntilDate = (id: number, hideUntilDate: string) =>
+  request<Task>(`/tasks/${id}/hide`, { method: 'POST', body: JSON.stringify({ hideUntilDate }) });
+
 export const unhideTask = (id: number) =>
   request<Task>(`/tasks/${id}/unhide`, { method: 'POST' });
 

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { Task, Settings, Blocker, TabName } from '../types';
 import { isStale } from '../utils/staleness';
 import { linkifyText } from '../utils/linkify';
@@ -19,6 +19,7 @@ interface Props {
   onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onHide: (id: number, durationMinutes: 15 | 30 | 60 | 120 | 240) => Promise<void>;
+  onHideUntilDate: (id: number, date: string) => Promise<void>;
   onUnhide: (id: number) => Promise<void>;
   onFocusToggle: (id: number, options?: { unhideFirst?: boolean }) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
@@ -46,21 +47,37 @@ function formatHiddenTimestamp(hiddenUntilAt: string | null): string {
   const until = new Date(hiddenUntilAt);
   if (Number.isNaN(until.getTime())) return 'Hidden temporarily';
 
-  const now = Date.now();
-  const remainingMs = until.getTime() - now;
-  const hiddenUntilLabel = until.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  const now = new Date();
+  const remainingMs = until.getTime() - now.getTime();
 
-  if (remainingMs <= 0) return `Hidden until ${hiddenUntilLabel} (returning now)`;
-  const remainingMinutes = Math.ceil(remainingMs / 60000);
-  if (remainingMinutes < 60) return `Hidden until ${hiddenUntilLabel} (in ${remainingMinutes}m)`;
+  if (remainingMs <= 0) {
+    const label = until.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    return `Hidden until ${label} (returning now)`;
+  }
 
-  const remainingHours = Math.ceil(remainingMinutes / 60);
-  return `Hidden until ${hiddenUntilLabel} (in ${remainingHours}h)`;
+  const isToday = until.toDateString() === now.toDateString();
+
+  if (isToday) {
+    const hiddenUntilLabel = until.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const remainingMinutes = Math.ceil(remainingMs / 60000);
+    if (remainingMinutes < 60) return `Hidden until ${hiddenUntilLabel} (in ${remainingMinutes}m)`;
+    const remainingHours = Math.ceil(remainingMinutes / 60);
+    return `Hidden until ${hiddenUntilLabel} (in ${remainingHours}h)`;
+  }
+
+  const tomorrowDate = new Date(now);
+  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+  if (until.toDateString() === tomorrowDate.toDateString()) {
+    return 'Hidden until tomorrow';
+  }
+
+  const dateLabel = until.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return `Hidden until ${dateLabel}`;
 }
 
 export default function TaskRow({
   task, settings, showStaleness, isPending, isFocused, allTasks, blockers, activeTab, recentlyUpdated,
-  onUpdate, onComplete, onHide, onUnhide, onFocusToggle, onUncomplete,
+  onUpdate, onComplete, onHide, onHideUntilDate, onUnhide, onFocusToggle, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete,
 }: Props) {
   const [editingTitle, setEditingTitle] = useState(false);
@@ -69,10 +86,24 @@ export default function TaskRow({
   const [statusValue, setStatusValue] = useState(task.status);
   const [showBlockers, setShowBlockers] = useState(activeTab === 'blocked');
   const [showHideMenu, setShowHideMenu] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [hideDateValue, setHideDateValue] = useState('');
   const skipNextTitleBlurSaveRef = useRef(false);
   const skipNextStatusBlurSaveRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const hideMenuRef = useRef<HTMLDivElement>(null);
+
+  const tomorrow = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return d.toISOString().slice(0, 10);
+  }, []);
+
+  const minPickerDate = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 2);
+    return d.toISOString().slice(0, 10);
+  }, []);
 
   const stale = showStaleness && isStale(task.updatedAt, settings);
   const bgColor = stale ? 'var(--row-stale)' : (task.priority ? ROW_COLORS[task.priority] : 'var(--row-idea)');
@@ -91,6 +122,7 @@ export default function TaskRow({
       if (!hideMenuRef.current) return;
       if (!hideMenuRef.current.contains(event.target as Node)) {
         setShowHideMenu(false);
+        setShowDatePicker(false);
       }
     };
 
@@ -297,16 +329,21 @@ export default function TaskRow({
               <div className="hide-menu" ref={hideMenuRef}>
                 <button
                   className="btn btn-sm btn-primary"
-                  onClick={() => setShowHideMenu(prev => !prev)}
+                  onClick={() => {
+                    setShowHideMenu(prev => {
+                      if (prev) setShowDatePicker(false);
+                      return !prev;
+                    });
+                  }}
                   disabled={isPending}
                   aria-haspopup="menu"
                   aria-expanded={showHideMenu}
-                  aria-label={`Hide ${task.title} for a short duration`}
+                  aria-label={`Hide ${task.title}`}
                 >
                   Hide
                 </button>
                 {showHideMenu && (
-                  <div className="hide-menu-popover" role="menu" aria-label={`Hide durations for ${task.title}`}>
+                  <div className="hide-menu-popover" role="menu" aria-label={`Hide options for ${task.title}`}>
                     {HIDE_PRESETS.map(preset => (
                       <button
                         key={preset.minutes}
@@ -321,6 +358,51 @@ export default function TaskRow({
                         {preset.label}
                       </button>
                     ))}
+                    <hr className="hide-menu-divider" />
+                    <button
+                      className="btn btn-sm btn-outline"
+                      onClick={() => {
+                        setShowHideMenu(false);
+                        void onHideUntilDate(task.id, tomorrow);
+                      }}
+                      disabled={isPending}
+                      role="menuitem"
+                    >
+                      Tomorrow
+                    </button>
+                    {!showDatePicker ? (
+                      <button
+                        className="btn btn-sm btn-outline"
+                        onClick={() => {
+                          setShowDatePicker(true);
+                          setHideDateValue('');
+                        }}
+                        disabled={isPending}
+                        role="menuitem"
+                      >
+                        Pick a date…
+                      </button>
+                    ) : (
+                      <div className="hide-date-picker" role="menuitem">
+                        <input
+                          type="date"
+                          min={minPickerDate}
+                          value={hideDateValue}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            setHideDateValue(val);
+                            if (val) {
+                              setShowHideMenu(false);
+                              setShowDatePicker(false);
+                              void onHideUntilDate(task.id, val);
+                            }
+                          }}
+                          disabled={isPending}
+                          autoFocus
+                          aria-label="Pick a date to hide until"
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/TaskTable.tsx
+++ b/src/components/TaskTable.tsx
@@ -18,6 +18,7 @@ interface Props {
   onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onHide: (id: number, durationMinutes: 15 | 30 | 60 | 120 | 240) => Promise<void>;
+  onHideUntilDate: (id: number, date: string) => Promise<void>;
   onUnhide: (id: number) => Promise<void>;
   onFocusToggle: (id: number, options?: { unhideFirst?: boolean }) => Promise<void>;
   onUncomplete: (id: number) => Promise<void>;
@@ -30,7 +31,7 @@ interface Props {
 
 export default function TaskTable({
   tasks, searchQuery, hasActiveSearch, settings, allTasks, blockers, pendingActionByTaskId, activeTab, loading, recentlyUpdatedIds,
-  focusedTaskId, onTabChange, onUpdate, onComplete, onHide, onUnhide, onFocusToggle, onUncomplete,
+  focusedTaskId, onTabChange, onUpdate, onComplete, onHide, onHideUntilDate, onUnhide, onFocusToggle, onUncomplete,
   onLoadBlockers, onAddBlocker, onRemoveBlocker, onPermanentDelete, onClearSearch,
 }: Props) {
   const showStaleness = activeTab === 'tasks';
@@ -131,6 +132,7 @@ export default function TaskTable({
           onUpdate={onUpdate}
           onComplete={onComplete}
           onHide={onHide}
+          onHideUntilDate={onHideUntilDate}
           onUnhide={onUnhide}
           onFocusToggle={onFocusToggle}
           onUncomplete={onUncomplete}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -53,6 +53,11 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
+  const hideUntilDate = async (id: number, date: string) => {
+    await api.hideTaskUntilDate(id, date);
+    await reload();
+  };
+
   const unhide = async (id: number) => {
     await api.unhideTask(id);
     await reload();
@@ -73,5 +78,5 @@ export function useTasks(tab: TabName) {
     await reload();
   };
 
-  return { tasks, loading, reload, create, update, complete, uncomplete, hide, unhide, focus, clearFocus, remove };
+  return { tasks, loading, reload, create, update, complete, uncomplete, hide, hideUntilDate, unhide, focus, clearFocus, remove };
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -519,6 +519,26 @@ textarea:focus-visible,
   white-space: nowrap;
 }
 
+.hide-menu-divider {
+  border: none;
+  border-top: 1px solid var(--border-light);
+  margin: 0.125rem 0;
+}
+
+.hide-date-picker {
+  width: 100%;
+}
+
+.hide-date-picker input[type="date"] {
+  width: 100%;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.8125rem;
+  border: 1px solid var(--border-light);
+  border-radius: 0.25rem;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
 /* Task Timestamp */
 .task-timestamp {
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Adds **"Tomorrow"** option to the hide submenu that hides tasks until midnight of the next day
- Adds **"Pick a date…"** option with an inline native date picker for hiding until any future date
- Updates the hidden tab timestamp to show "Hidden until tomorrow" or "Hidden until Mar 20" for multi-day hides
- Extends the server hide endpoint to accept `hideUntilDate` (YYYY-MM-DD) as an alternative to `durationMinutes`

## Test plan
- [x] Open Tasks tab, click Hide on a task — verify menu shows 15m/30m/1h/2h/4h, divider, Tomorrow, Pick a date…
- [x] Click "Tomorrow" — task moves to Hidden tab showing "Hidden until tomorrow"
- [x] Unhide, click "Pick a date…", select a future date — task moves to Hidden tab showing "Hidden until [date]"
- [x] Verify undo toast works for both new hide options
- [x] Run `npx tsc --noEmit` and `npx tsc -p tsconfig.server.json --noEmit` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)