### PR TITLE
Add desktop packaging and data-safe self-update flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 server/dist
+release
 data/tasks.json
 data/server.log
 data/server-error.log

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/svakili/stradl/actions/workflows/ci.yml/badge.svg)](https://github.com/svakili/stradl/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-A single-user local task management web app for multitasking. Tracks tasks with priorities (P0/P1/P2/Ideas), free-text statuses, blocking relationships, and staleness indicators. Installable as a PWA.
+A single-user local task management app for multitasking. Tracks tasks with priorities (P0/P1/P2/Ideas), free-text statuses, blocking relationships, and staleness indicators. The same React UI can run as a browser/PWA build or as a packaged macOS desktop app with one-click updates.
 
 > Project status: early-stage. Current contribution scope is intentionally narrow to docs and small fixes. See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -23,9 +23,8 @@ This starts the Express API server on port 3001 and the Vite dev server on port 
 ## Platform Support
 
 - Development workflow: cross-platform (macOS, Linux, Windows with Node 18+)
-- Runtime operational extras: macOS-only
-  - LaunchAgent auto-start scripts
-  - In-app self-update flow that restarts via `launchctl`
+- Packaged desktop runtime: macOS-only
+- Legacy LaunchAgent/runtime extras: macOS-only
 
 ## Production
 
@@ -36,14 +35,54 @@ npm start
 
 Builds the frontend and compiles the server TypeScript, then serves everything from http://localhost:3001.
 
+## Desktop App (macOS)
+
+Build a packaged desktop app:
+
+```bash
+npm run package:desktop
+```
+
+This produces:
+
+- `release/Stradl-mac-arm64-v<version>.zip`
+- `release/SHA256SUMS.txt`
+
+Install the app by unzipping it and moving `Stradl.app` into `~/Applications`.
+
+Desktop runtime notes:
+
+- packaged desktop builds disable the PWA/service worker layer
+- the Electron shell starts the same local Express API on a loopback port
+- desktop self-update is only enabled for packaged apps installed in `~/Applications`
+- update artifacts are downloaded from GitHub Releases and verified against `SHA256SUMS.txt`
+
+## Moving Tasks Safely
+
+The app keeps its canonical data file at:
+
+`~/Library/Application Support/Stradl/tasks.json`
+
+The Settings panel includes:
+
+- `Export tasks` to download a full JSON backup
+- `Import tasks` to replace the current data after creating an automatic backup
+
+Automatic backups are written to:
+
+`~/Library/Application Support/Stradl/backups/`
+
+During desktop updates, Stradl creates a `pre-update` snapshot before replacing the app bundle.
+
 ## Releasing
 
 This project includes one-command release scripts that:
 - ensure you are on a clean `main` branch
 - pull latest `origin/main`
 - bump version + create tag via `npm version`
+- build the packaged desktop zip and `SHA256SUMS.txt`
 - push commit and tag
-- create a GitHub release with generated notes
+- create a GitHub release with generated notes and upload the desktop artifacts
 
 Use one of:
 
@@ -56,9 +95,14 @@ npm run release:major
 Notes:
 - Requires `gh` authenticated (`gh auth status`)
 - Release tags are `v<version>` and match `package.json` version
+- Releases upload `release/Stradl-mac-*.zip` and `release/SHA256SUMS.txt`
 - Intended for maintainers
 
-## Auto-Start on Login (macOS-only runtime feature)
+## Legacy LaunchAgent Mode (macOS-only)
+
+This mode keeps the old `http://localhost:3001` server running outside the packaged desktop app. It is still available for repo-based installs, but the packaged Electron app is now the primary runtime for one-click updates.
+
+### Auto-Start on Login
 
 ```bash
 npm run install-service
@@ -72,7 +116,7 @@ To disable:
 npm run uninstall-service
 ```
 
-## In-App Self-Update (macOS-only runtime feature)
+### Legacy In-App Self-Update
 
 The Settings panel can check for updates and apply the latest `origin/main` automatically.
 
@@ -110,7 +154,9 @@ If preflight checks fail, the API returns a clear error:
 - **Staleness** -- Tasks not updated within the threshold turn purple
 - **Vacation mode** -- Add offset hours so tasks don't go stale while you're away
 - **Top N limiting** -- Only show the top N tasks in the Tasks tab
-- **PWA** -- Installable from the browser for a native app feel
+- **Task backup/import** -- Move tasks between installs or machines with explicit export/import
+- **Desktop packaging** -- macOS Electron app with quit-install-relaunch updates
+- **PWA** -- Browser install option for web/dev usage
 
 ## Contributing
 
@@ -123,8 +169,9 @@ If preflight checks fail, the API returns a clear error:
 
 ```
 server/           Express API + JSON file storage
+electron/         Electron shell + desktop updater
 src/              React frontend (Vite)
-scripts/          macOS Launch Agent install/uninstall helpers
+scripts/          release + packaging helpers
 ```
 
 ## Data Storage
@@ -142,3 +189,4 @@ Migration behavior:
   - `<project>/data/tasks.json`
   - `<project>/server/data/tasks.json`
 - If the destination file already exists, Stradl keeps it and does not overwrite it.
+- Persisted exports include `schemaVersion` so future migrations can be applied safely.

--- a/electron/install-helper.mjs
+++ b/electron/install-helper.mjs
@@ -1,0 +1,144 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      parsed[key] = 'true';
+      continue;
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function writeStatus(statusPath, status) {
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
+}
+
+async function waitForProcessExit(pid) {
+  const deadline = Date.now() + 60_000;
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    } catch (error) {
+      const maybeError = error;
+      if (maybeError && typeof maybeError === 'object' && maybeError.code === 'ESRCH') {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error('Timed out waiting for the running app to exit.');
+}
+
+function runOrThrow(command, args, errorMessage) {
+  const result = spawnSync(command, args, { encoding: 'utf-8' });
+  if (result.status === 0) {
+    return;
+  }
+  const details = result.stderr?.trim() || result.stdout?.trim() || errorMessage;
+  throw new Error(details);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const statusPath = args['status-file'];
+const targetApp = args['target-app'];
+const stagedApp = args['staged-app'];
+const currentPid = Number(args['current-pid']);
+const operationId = args['operation-id'];
+const startedAt = args['started-at'];
+const fromVersion = args['from-version'];
+const toVersion = args['to-version'];
+
+if (!statusPath || !targetApp || !stagedApp || !currentPid || !operationId || !startedAt || !toVersion) {
+  console.error('Missing required installer arguments.');
+  process.exit(1);
+}
+
+const backupRoot = path.join(path.dirname(statusPath), 'updates', toVersion, 'previous');
+const backupAppPath = path.join(backupRoot, path.basename(targetApp));
+
+try {
+  writeStatus(statusPath, {
+    state: 'running',
+    step: 'waiting-for-exit',
+    message: 'Waiting for the running app to exit before replacing it.',
+    operationId,
+    startedAt,
+    fromVersion,
+    toVersion,
+  });
+  await waitForProcessExit(currentPid);
+
+  fs.mkdirSync(path.dirname(targetApp), { recursive: true });
+  fs.mkdirSync(backupRoot, { recursive: true });
+
+  if (fs.existsSync(backupAppPath)) {
+    fs.rmSync(backupAppPath, { recursive: true, force: true });
+  }
+
+  if (fs.existsSync(targetApp)) {
+    fs.renameSync(targetApp, backupAppPath);
+  }
+
+  fs.renameSync(stagedApp, targetApp);
+
+  writeStatus(statusPath, {
+    state: 'running',
+    step: 'relaunching',
+    message: 'Launching the updated app.',
+    operationId,
+    startedAt,
+    fromVersion,
+    toVersion,
+  });
+
+  runOrThrow('open', ['-n', targetApp], 'Failed to relaunch Stradl.');
+
+  fs.rmSync(backupAppPath, { recursive: true, force: true });
+
+  writeStatus(statusPath, {
+    state: 'succeeded',
+    step: 'completed',
+    message: 'Update applied successfully.',
+    operationId,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    fromVersion,
+    toVersion,
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'Failed to install updated app.';
+
+  if (!fs.existsSync(targetApp) && fs.existsSync(backupAppPath)) {
+    try {
+      fs.renameSync(backupAppPath, targetApp);
+    } catch {
+      // Keep the original failure message.
+    }
+  }
+
+  writeStatus(statusPath, {
+    state: 'failed',
+    step: 'failed',
+    message,
+    operationId,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    fromVersion,
+    toVersion,
+  });
+  process.exit(1);
+}

--- a/electron/install-helper.mjs
+++ b/electron/install-helper.mjs
@@ -21,7 +21,10 @@ function parseArgs(argv) {
 
 function writeStatus(statusPath, status) {
   fs.mkdirSync(path.dirname(statusPath), { recursive: true });
-  fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
+  fs.writeFileSync(statusPath, JSON.stringify({
+    ...status,
+    processId: status.state === 'running' ? process.pid : status.processId,
+  }, null, 2));
 }
 
 async function waitForProcessExit(pid) {

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -1,0 +1,162 @@
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import { createDesktopUpdater } from './updater.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let mainWindow = null;
+let serverHandle = null;
+let updater = null;
+
+function getCanonicalDataDir() {
+  return path.join(app.getPath('appData'), 'Stradl');
+}
+
+function getBundledDistPath() {
+  return path.join(app.getAppPath(), 'dist');
+}
+
+function getInstalledAppBundlePath() {
+  const executablePath = app.getPath('exe');
+  if (executablePath.includes('.app/Contents/MacOS/')) {
+    return path.resolve(executablePath, '..', '..', '..');
+  }
+  return app.getAppPath();
+}
+
+function canSelfUpdate() {
+  if (process.platform !== 'darwin') return false;
+  if (!app.isPackaged) {
+    return process.env.STRADL_ENABLE_DESKTOP_UPDATE === 'true';
+  }
+
+  const installedPath = getInstalledAppBundlePath();
+  return installedPath.startsWith(path.join(os.homedir(), 'Applications'));
+}
+
+async function startEmbeddedServer() {
+  process.env.STRADL_DATA_DIR = getCanonicalDataDir();
+  const { startServer } = await import(new URL('../server/dist/app.js', import.meta.url));
+  return startServer({
+    host: '127.0.0.1',
+    port: 0,
+    distPath: getBundledDistPath(),
+  });
+}
+
+async function snapshotData(reason) {
+  if (!serverHandle) {
+    throw new Error('Server is not running.');
+  }
+
+  const response = await fetch(`http://127.0.0.1:${serverHandle.port}/api/data/snapshot`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reason }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || 'Failed to snapshot data before update.');
+  }
+
+  return response.json();
+}
+
+function createMainWindow() {
+  if (!serverHandle) {
+    throw new Error('Server must be started before creating the window.');
+  }
+
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 960,
+    minWidth: 1024,
+    minHeight: 720,
+    show: false,
+    title: 'Stradl',
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: false,
+      preload: path.join(__dirname, 'preload.cjs'),
+    },
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  mainWindow.once('ready-to-show', () => {
+    mainWindow?.show();
+  });
+
+  void mainWindow.loadURL(`http://127.0.0.1:${serverHandle.port}`);
+}
+
+function registerIpcHandlers() {
+  ipcMain.handle('runtime:get-info', async () => ({
+    mode: 'desktop-local',
+    appVersion: app.getVersion(),
+    canSelfUpdate: canSelfUpdate(),
+  }));
+
+  ipcMain.handle('updates:check', async () => {
+    if (!updater) {
+      throw new Error('Updater is unavailable.');
+    }
+    return updater.checkForUpdates();
+  });
+
+  ipcMain.handle('updates:apply', async () => {
+    if (!updater) {
+      throw new Error('Updater is unavailable.');
+    }
+    return updater.applyUpdate();
+  });
+
+  ipcMain.handle('updates:status', async () => {
+    if (!updater) {
+      return { state: 'idle', step: 'idle' };
+    }
+    return updater.getStatus();
+  });
+}
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createMainWindow();
+  }
+});
+
+app.on('before-quit', () => {
+  serverHandle?.server.close();
+});
+
+await app.whenReady();
+
+serverHandle = await startEmbeddedServer();
+updater = createDesktopUpdater({
+  app,
+  appBundlePath: getInstalledAppBundlePath(),
+  dataDir: getCanonicalDataDir(),
+  canSelfUpdate,
+  snapshotData,
+});
+
+updater.onStatus((status) => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send('desktop:update-status', status);
+  }
+});
+
+registerIpcHandlers();
+createMainWindow();

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -79,7 +79,7 @@ function createMainWindow() {
     title: 'Stradl',
     webPreferences: {
       contextIsolation: true,
-      sandbox: false,
+      sandbox: true,
       preload: path.join(__dirname, 'preload.cjs'),
     },
   });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,13 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('stradlDesktop', {
+  getRuntimeInfo: () => ipcRenderer.invoke('runtime:get-info'),
+  checkForUpdates: () => ipcRenderer.invoke('updates:check'),
+  applyUpdate: () => ipcRenderer.invoke('updates:apply'),
+  getUpdateStatus: () => ipcRenderer.invoke('updates:status'),
+  onUpdateStatus: (listener) => {
+    const handler = (_event, status) => listener(status);
+    ipcRenderer.on('desktop:update-status', handler);
+    return () => ipcRenderer.removeListener('desktop:update-status', handler);
+  },
+});

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -1,0 +1,413 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import { spawn, spawnSync } from 'child_process';
+import { EventEmitter } from 'events';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function normalizeVersion(value) {
+  return value.trim().replace(/^v/i, '');
+}
+
+function parseSemver(value) {
+  const normalized = normalizeVersion(value);
+  const match = normalized.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error('Invalid version format.');
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isVersionNewer(latest, current) {
+  const [latestMajor, latestMinor, latestPatch] = parseSemver(latest);
+  const [currentMajor, currentMinor, currentPatch] = parseSemver(current);
+
+  if (latestMajor !== currentMajor) return latestMajor > currentMajor;
+  if (latestMinor !== currentMinor) return latestMinor > currentMinor;
+  return latestPatch > currentPatch;
+}
+
+function makeStatusPath(dataDir) {
+  return path.join(dataDir, 'update-status.json');
+}
+
+function writeStatusFile(statusPath, status) {
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
+}
+
+function readStatusFile(statusPath) {
+  if (!fs.existsSync(statusPath)) {
+    return { state: 'idle', step: 'idle' };
+  }
+
+  try {
+    const raw = fs.readFileSync(statusPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return { state: 'idle', step: 'idle' };
+    }
+    return parsed;
+  } catch {
+    return { state: 'idle', step: 'idle' };
+  }
+}
+
+async function fetchLatestRelease(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'stradl-desktop-updater',
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to check updates (GitHub ${response.status}).`);
+  }
+
+  const release = await response.json();
+  if (
+    typeof release.tag_name !== 'string' ||
+    typeof release.html_url !== 'string' ||
+    typeof release.published_at !== 'string' ||
+    !Array.isArray(release.assets)
+  ) {
+    throw new Error('GitHub release response missing required fields.');
+  }
+
+  return {
+    latestVersion: normalizeVersion(release.tag_name),
+    releaseUrl: release.html_url,
+    releaseName: typeof release.name === 'string' && release.name.trim()
+      ? release.name
+      : release.tag_name,
+    publishedAt: release.published_at,
+    assets: release.assets,
+  };
+}
+
+function expectedArtifactName(version) {
+  const architecture = process.arch === 'arm64' ? 'arm64' : 'x64';
+  return `Stradl-mac-${architecture}-v${version}.zip`;
+}
+
+function chooseReleaseAsset(release) {
+  const artifactName = expectedArtifactName(release.latestVersion);
+  const artifact = release.assets.find((asset) => asset && asset.name === artifactName);
+  if (!artifact || typeof artifact.browser_download_url !== 'string') {
+    throw new Error(`Release asset is missing: ${artifactName}`);
+  }
+
+  const checksumFile = release.assets.find((asset) => asset && asset.name === 'SHA256SUMS.txt');
+  if (!checksumFile || typeof checksumFile.browser_download_url !== 'string') {
+    throw new Error('Release is missing SHA256SUMS.txt.');
+  }
+
+  return { artifact, checksumFile };
+}
+
+async function downloadFile(url, destinationPath) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download update artifact (${response.status}).`);
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+  await new Promise((resolve, reject) => {
+    const fileStream = fs.createWriteStream(destinationPath);
+    const readable = Readable.fromWeb(response.body);
+    readable.on('error', reject);
+    fileStream.on('error', reject);
+    fileStream.on('finish', resolve);
+    readable.pipe(fileStream);
+  });
+}
+
+async function fetchExpectedChecksum(url, artifactName) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download checksum file (${response.status}).`);
+  }
+
+  const body = await response.text();
+  const line = body.split(/\r?\n/).find((entry) => entry.trim().endsWith(artifactName));
+  if (!line) {
+    throw new Error(`Checksum not found for ${artifactName}.`);
+  }
+
+  const [hash] = line.trim().split(/\s+/);
+  if (!hash) {
+    throw new Error(`Checksum line is invalid for ${artifactName}.`);
+  }
+  return hash;
+}
+
+function computeSha256(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+function runOrThrow(command, args, errorMessage) {
+  const result = spawnSync(command, args, { encoding: 'utf-8' });
+  if (result.status === 0) {
+    return;
+  }
+
+  const details = result.stderr?.trim() || result.stdout?.trim() || errorMessage;
+  throw new Error(details);
+}
+
+function findAppBundle(rootPath) {
+  const entries = fs.readdirSync(rootPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isDirectory() && entry.name.endsWith('.app')) {
+      return entryPath;
+    }
+    if (entry.isDirectory()) {
+      const nested = findAppBundle(entryPath);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function spawnInstallHelper({
+  statusPath,
+  targetAppPath,
+  stagedAppPath,
+  currentPid,
+  operationId,
+  startedAt,
+  fromVersion,
+  toVersion,
+}) {
+  const helperPath = path.join(__dirname, 'install-helper.mjs');
+
+  const child = spawn(process.execPath, [
+    helperPath,
+    '--status-file', statusPath,
+    '--target-app', targetAppPath,
+    '--staged-app', stagedAppPath,
+    '--current-pid', String(currentPid),
+    '--operation-id', operationId,
+    '--started-at', startedAt,
+    '--from-version', fromVersion,
+    '--to-version', toVersion,
+  ], {
+    detached: true,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+    },
+  });
+  child.unref();
+}
+
+export function createDesktopUpdater({
+  app,
+  appBundlePath,
+  dataDir,
+  canSelfUpdate,
+  snapshotData,
+}) {
+  const statusPath = makeStatusPath(dataDir);
+  const events = new EventEmitter();
+  let updateInFlight = false;
+
+  function setStatus(status) {
+    writeStatusFile(statusPath, status);
+    events.emit('status', status);
+  }
+
+  function getStatus() {
+    const status = readStatusFile(statusPath);
+    if (status.state !== 'running') {
+      updateInFlight = false;
+    }
+    return status;
+  }
+
+  async function checkForUpdates() {
+    const currentVersion = normalizeVersion(app.getVersion());
+    const checkedAt = new Date().toISOString();
+    const owner = process.env.STRADL_UPDATE_OWNER || 'svakili';
+    const repo = process.env.STRADL_UPDATE_REPO || 'stradl';
+    const release = await fetchLatestRelease(owner, repo);
+
+    return {
+      currentVersion,
+      latestVersion: release.latestVersion,
+      hasUpdate: isVersionNewer(release.latestVersion, currentVersion),
+      releaseUrl: release.releaseUrl,
+      releaseName: release.releaseName,
+      publishedAt: release.publishedAt,
+      checkedAt,
+    };
+  }
+
+  async function applyUpdate() {
+    if (!canSelfUpdate()) {
+      throw new Error('Desktop self-update is only enabled for packaged apps installed in ~/Applications.');
+    }
+
+    const existingStatus = getStatus();
+    if (updateInFlight || existingStatus.state === 'running') {
+      throw new Error('An update is already running.');
+    }
+
+    const operationId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const startedAt = new Date().toISOString();
+    const fromVersion = normalizeVersion(app.getVersion());
+
+    setStatus({
+      state: 'running',
+      step: 'queued',
+      message: 'Update queued.',
+      operationId,
+      startedAt,
+      fromVersion,
+    });
+    updateInFlight = true;
+
+    void (async () => {
+      try {
+        setStatus({
+          state: 'running',
+          step: 'snapshotting-data',
+          message: 'Creating a backup of local tasks before update.',
+          operationId,
+          startedAt,
+          fromVersion,
+        });
+        await snapshotData('pre-update');
+
+        const owner = process.env.STRADL_UPDATE_OWNER || 'svakili';
+        const repo = process.env.STRADL_UPDATE_REPO || 'stradl';
+        const release = await fetchLatestRelease(owner, repo);
+        const { artifact, checksumFile } = chooseReleaseAsset(release);
+        const updateRoot = path.join(dataDir, 'updates', release.latestVersion);
+        const archivePath = path.join(updateRoot, artifact.name);
+        const stagingRoot = path.join(updateRoot, 'staging');
+
+        setStatus({
+          state: 'running',
+          step: 'downloading',
+          message: `Downloading v${release.latestVersion}.`,
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+        await downloadFile(artifact.browser_download_url, archivePath);
+
+        setStatus({
+          state: 'running',
+          step: 'verifying',
+          message: 'Verifying downloaded update.',
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+        const expectedHash = await fetchExpectedChecksum(checksumFile.browser_download_url, artifact.name);
+        const actualHash = computeSha256(archivePath);
+        if (expectedHash.toLowerCase() !== actualHash.toLowerCase()) {
+          throw new Error('Downloaded update checksum did not match SHA256SUMS.txt.');
+        }
+
+        fs.rmSync(stagingRoot, { recursive: true, force: true });
+        fs.mkdirSync(stagingRoot, { recursive: true });
+
+        setStatus({
+          state: 'running',
+          step: 'staging',
+          message: 'Preparing the new app version.',
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+        runOrThrow('ditto', ['-xk', archivePath, stagingRoot], 'Failed to extract update archive.');
+
+        const stagedAppPath = findAppBundle(stagingRoot);
+        if (!stagedAppPath) {
+          throw new Error('Extracted update archive did not contain a .app bundle.');
+        }
+
+        spawnSync('xattr', ['-dr', 'com.apple.quarantine', stagedAppPath], { encoding: 'utf-8' });
+
+        setStatus({
+          state: 'running',
+          step: 'waiting-for-exit',
+          message: 'Closing current version to install the update.',
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+
+        spawnInstallHelper({
+          statusPath,
+          targetAppPath: appBundlePath,
+          stagedAppPath,
+          currentPid: process.pid,
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+
+        setStatus({
+          state: 'running',
+          step: 'relaunching',
+          message: 'Installing update and relaunching Stradl.',
+          operationId,
+          startedAt,
+          fromVersion,
+          toVersion: release.latestVersion,
+        });
+
+        setTimeout(() => app.quit(), 250);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to apply update.';
+        setStatus({
+          state: 'failed',
+          step: 'failed',
+          message,
+          operationId,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          fromVersion,
+        });
+        updateInFlight = false;
+      }
+    })();
+
+    return {
+      operationId,
+      startedAt,
+      targetVersion: undefined,
+    };
+  }
+
+  return {
+    checkForUpdates,
+    applyUpdate,
+    getStatus,
+    onStatus(listener) {
+      events.on('status', listener);
+      return () => events.off('status', listener);
+    },
+  };
+}

--- a/electron/updater.mjs
+++ b/electron/updater.mjs
@@ -7,6 +7,11 @@ import { EventEmitter } from 'events';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RUNNING_STATUS_TTL_MS = 60 * 60 * 1000;
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
 function normalizeVersion(value) {
   return value.trim().replace(/^v/i, '');
@@ -39,6 +44,29 @@ function writeStatusFile(statusPath, status) {
   fs.writeFileSync(statusPath, JSON.stringify(status, null, 2));
 }
 
+function isProcessAlive(pid) {
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(error && typeof error === 'object' && error.code === 'ESRCH');
+  }
+}
+
+function coerceTerminalStatus(parsed, message) {
+  return {
+    ...parsed,
+    state: 'failed',
+    step: 'failed',
+    message,
+    finishedAt: new Date().toISOString(),
+  };
+}
+
 function readStatusFile(statusPath) {
   if (!fs.existsSync(statusPath)) {
     return { state: 'idle', step: 'idle' };
@@ -47,9 +75,21 @@ function readStatusFile(statusPath) {
   try {
     const raw = fs.readFileSync(statusPath, 'utf-8');
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object') {
+    if (!isRecord(parsed)) {
       return { state: 'idle', step: 'idle' };
     }
+
+    if (parsed.state === 'running') {
+      const startedAt = typeof parsed.startedAt === 'string' ? Date.parse(parsed.startedAt) : Number.NaN;
+      if (!Number.isNaN(startedAt) && Date.now() - startedAt > RUNNING_STATUS_TTL_MS) {
+        return coerceTerminalStatus(parsed, 'Recovered a stale update state. Please try the update again.');
+      }
+
+      if (typeof parsed.processId === 'number' && !isProcessAlive(parsed.processId)) {
+        return coerceTerminalStatus(parsed, 'Recovered an interrupted update. Please try the update again.');
+      }
+    }
+
     return parsed;
   } catch {
     return { state: 'idle', step: 'idle' };
@@ -226,12 +266,19 @@ export function createDesktopUpdater({
   let updateInFlight = false;
 
   function setStatus(status) {
-    writeStatusFile(statusPath, status);
-    events.emit('status', status);
+    const nextStatus = {
+      ...status,
+      processId: status.state === 'running' ? process.pid : status.processId,
+    };
+    writeStatusFile(statusPath, nextStatus);
+    events.emit('status', nextStatus);
   }
 
   function getStatus() {
     const status = readStatusFile(statusPath);
+    if (status.state === 'failed' && status.finishedAt && status.message?.startsWith('Recovered')) {
+      writeStatusFile(statusPath, status);
+    }
     if (status.state !== 'running') {
       updateInFlight = false;
     }
@@ -389,6 +436,7 @@ export function createDesktopUpdater({
           startedAt,
           finishedAt: new Date().toISOString(),
           fromVersion,
+          processId: process.pid,
         });
         updateInFlight = false;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.0",
         "concurrently": "^9.2.1",
+        "electron": "^29.4.6",
+        "electron-builder": "^24.13.3",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vite": "^5.4.0",
@@ -1509,6 +1511,289 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron/get/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/get/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
+      "integrity": "sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.5.tgz",
+      "integrity": "sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==",
+      "dev": true,
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.5.1.tgz",
+      "integrity": "sha512-kbgXxyEauPJiQQUNG2VgUeyfQNFk6hBF11ISN2PNI6agUgPl55pv4eQmaqHzTAzchBvqZ2tQuRVaPStGf0mxGw==",
+      "dev": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "@malept/cross-spawn-promise": "^1.1.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^3.0.0",
+        "fs-extra": "^9.0.1",
+        "minimatch": "^3.0.4",
+        "plist": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -1989,6 +2274,53 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2400,6 +2732,18 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2416,6 +2760,27 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2469,6 +2834,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2486,6 +2863,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -2524,16 +2910,46 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2543,6 +2959,17 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
       }
     },
     "node_modules/@types/prop-types": {
@@ -2588,6 +3015,15 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true
     },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -2623,6 +3059,23 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2731,6 +3184,21 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2753,6 +3221,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2794,6 +3274,247 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "dev": true
+    },
+    "node_modules/app-builder-lib": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.13.3.tgz",
+      "integrity": "sha512-FAzX6IBit2POXYGnTCT8YHFO/lr5AapAII6zzhQO3Rw4cEDOgK+t1xhLc5tNcKlicTHlo9zxIwnYCX9X2DLkig==",
+      "dev": true,
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.2.1",
+        "@electron/osx-sign": "1.0.5",
+        "@electron/universal": "1.5.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "24.13.1",
+        "builder-util-runtime": "9.2.4",
+        "chromium-pickle-js": "^0.2.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "electron-publish": "24.13.1",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^5.1.1",
+        "read-config-file": "6.3.2",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "24.13.3",
+        "electron-builder-squirrel-windows": "24.13.3"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/app-builder-lib/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2837,6 +3558,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2846,11 +3577,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2860,6 +3610,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2933,6 +3689,26 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2943,6 +3719,33 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.5"
       }
     },
     "node_modules/body-parser": {
@@ -2980,6 +3783,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "5.0.2",
@@ -3026,11 +3837,107 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/builder-util": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.13.1.tgz",
+      "integrity": "sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "4.0.0",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.4",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+      "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3038,6 +3945,33 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -3142,6 +4076,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3154,6 +4135,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -3174,6 +4167,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3188,6 +4193,37 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concurrently": {
       "version": "9.2.1",
@@ -3212,6 +4248,200 @@
       },
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
+      "integrity": "sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^10.3.10",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/content-disposition": {
@@ -3263,6 +4493,49 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cross-spawn": {
@@ -3362,6 +4635,33 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3369,6 +4669,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -3405,6 +4714,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3422,6 +4740,159 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+      "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
+      "dev": true,
+      "dependencies": {
+        "buffer-equal": "^1.0.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
+      "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
+      "dev": true,
+      "dependencies": {
+        "app-builder-lib": "24.13.3",
+        "builder-util": "24.13.1",
+        "builder-util-runtime": "9.2.4",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dmg-license/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dmg-license/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3434,6 +4905,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3455,10 +4932,152 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.4.6.tgz",
+      "integrity": "sha512-fz8ndj8cmmf441t4Yh2FDP3Rn0JhLkVGvtUf2YVMbJ5SdJPlc0JWll9jYkhh60jDKVVCr/tBAmfxqRnXMWJpzg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.13.3.tgz",
+      "integrity": "sha512-yZSgVHft5dNVlo31qmJAe4BVKQfFdwpRw7sFp1iQglDRCDD6r22zfRJuZlhtB5gp9FHUxCMEoWGq10SkCnMAIg==",
+      "dev": true,
+      "dependencies": {
+        "app-builder-lib": "24.13.3",
+        "builder-util": "24.13.1",
+        "builder-util-runtime": "9.2.4",
+        "chalk": "^4.1.2",
+        "dmg-builder": "24.13.3",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "read-config-file": "6.3.2",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-24.13.3.tgz",
+      "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "24.13.3",
+        "archiver": "^5.3.1",
+        "builder-util": "24.13.1",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
+      "integrity": "sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "24.13.1",
+        "builder-util-runtime": "9.2.4",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3474,6 +5093,30 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -3608,6 +5251,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -3662,6 +5312,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
@@ -3753,6 +5416,36 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3780,6 +5473,15 @@
           "url": "https://opencollective.com/fastify"
         }
       ]
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -3878,6 +5580,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3894,6 +5612,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -3908,6 +5633,42 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4028,6 +5789,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -4081,6 +5857,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -4106,6 +5913,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4199,6 +6031,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4218,6 +6086,63 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4234,6 +6159,37 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "dev": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -4339,6 +6295,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -4650,6 +6618,18 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4693,6 +6673,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4705,6 +6697,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -4716,6 +6714,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4750,6 +6755,74 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4771,11 +6844,46 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4786,6 +6894,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
@@ -4804,6 +6921,19 @@
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4868,6 +6998,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
@@ -4883,6 +7022,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4890,6 +7038,49 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4923,11 +7114,40 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -4990,6 +7210,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -5007,6 +7236,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5019,6 +7257,15 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5072,6 +7319,12 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5088,6 +7341,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5139,6 +7406,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5149,6 +7445,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -5172,6 +7478,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/randombytes": {
@@ -5235,6 +7553,78 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-config-file": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
+      "integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
+      "dev": true,
+      "dependencies": {
+        "config-file-ts": "^0.2.4",
+        "dotenv": "^9.0.2",
+        "dotenv-expand": "^5.1.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.0",
+        "lazy-val": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5370,6 +7760,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -5377,6 +7773,45 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/rollup": {
@@ -5508,6 +7943,24 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -5524,6 +7977,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -5560,6 +8020,35 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -5754,6 +8243,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smob": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
@@ -5811,11 +8350,27 @@
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -5844,7 +8399,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -5967,6 +8547,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -5974,6 +8567,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/supports-color": {
@@ -6003,6 +8608,56 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6010,6 +8665,30 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tempy": {
@@ -6117,6 +8796,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -6141,6 +8838,15 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/tslib": {
@@ -6412,6 +9118,28 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -6426,6 +9154,21 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/vite": {
@@ -7581,6 +10324,39 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7621,6 +10397,106 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/zip-stream/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/zip-stream/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,16 +2,25 @@
   "name": "stradl",
   "version": "1.1.0",
   "private": true,
+  "description": "Local task management app with priorities, blockers, and backups",
+  "author": "Soheyl Vakili",
+  "main": "electron/main.mjs",
   "engines": {
     "node": ">=18"
   },
   "type": "module",
   "scripts": {
     "dev": "concurrently \"tsx watch server/index.ts\" \"vite\"",
-    "build": "vite build && tsc -p tsconfig.server.json",
+    "build:web": "vite build",
+    "build:web:desktop": "vite build --mode desktop",
+    "build:server": "tsc -p tsconfig.server.json",
+    "build": "npm run build:web && npm run build:server",
+    "build:desktop": "npm run build:web:desktop && npm run build:server",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
     "verify": "npm run build && npm test",
     "start": "node server/dist/index.js",
+    "start:desktop": "npm run build:desktop && electron .",
+    "package:desktop": "npm run build:desktop && electron-builder --mac zip --publish never && node scripts/generate-checksums.js release",
     "preview": "vite preview",
     "install-service": "node scripts/install-service.js",
     "uninstall-service": "node scripts/uninstall-service.js",
@@ -32,10 +41,33 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",
     "concurrently": "^9.2.1",
+    "electron": "^29.4.6",
+    "electron-builder": "^24.13.3",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",
     "vite": "^5.4.0",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.0.18"
+  },
+  "build": {
+    "appId": "com.stradl.desktop",
+    "productName": "Stradl",
+    "asar": false,
+    "directories": {
+      "output": "release"
+    },
+    "files": [
+      "dist/**/*",
+      "electron/**/*",
+      "server/dist/**/*",
+      "package.json"
+    ],
+    "mac": {
+      "target": [
+        "zip"
+      ],
+      "category": "public.app-category.productivity",
+      "artifactName": "Stradl-mac-${arch}-v${version}.${ext}"
+    }
   }
 }

--- a/scripts/generate-checksums.js
+++ b/scripts/generate-checksums.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const outputDir = process.argv[2]
+  ? path.resolve(projectRoot, process.argv[2])
+  : path.join(projectRoot, 'release');
+
+if (!fs.existsSync(outputDir)) {
+  console.error(`Release directory does not exist: ${outputDir}`);
+  process.exit(1);
+}
+
+const zipFiles = fs.readdirSync(outputDir)
+  .filter((name) => name.endsWith('.zip'))
+  .sort();
+
+if (zipFiles.length === 0) {
+  console.error(`No zip artifacts found in ${outputDir}`);
+  process.exit(1);
+}
+
+const lines = zipFiles.map((fileName) => {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(path.join(outputDir, fileName)));
+  return `${hash.digest('hex')}  ${fileName}`;
+});
+
+const outputPath = path.join(outputDir, 'SHA256SUMS.txt');
+fs.writeFileSync(outputPath, `${lines.join('\n')}\n`);
+console.log(`Wrote ${outputPath}`);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -57,12 +57,13 @@ if (dirty) {
 run('git fetch origin main');
 run('git pull --ff-only origin main');
 run(`npm version ${bump}`);
+run('npm run package:desktop');
 
 const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 const version = pkg.version;
 const tag = `v${version}`;
 
 run('git push origin main --follow-tags');
-run(`gh release create ${tag} --generate-notes`);
+run(`gh release create ${tag} release/Stradl-mac-*.zip release/SHA256SUMS.txt --generate-notes`);
 
 console.log(`\nRelease complete: ${tag}`);

--- a/server/__tests__/data-routes.test.ts
+++ b/server/__tests__/data-routes.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../storage.js', () => ({
+  createDataSnapshot: vi.fn(),
+  exportData: vi.fn(),
+  importData: vi.fn(),
+}));
+
+import { createDataSnapshot, exportData, importData } from '../storage.js';
+import { dataRoutes } from '../routes/data.js';
+
+const mockedCreateDataSnapshot = vi.mocked(createDataSnapshot);
+const mockedExportData = vi.mocked(exportData);
+const mockedImportData = vi.mocked(importData);
+
+function findHandler(method: string, routePath: string) {
+  const layer = (dataRoutes as any).stack.find((s: any) =>
+    s.route?.path === routePath && s.route?.methods[method]
+  );
+  if (!layer) throw new Error(`No handler for ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack.find((s: any) => s.method === method).handle;
+}
+
+function mockReq(overrides: Record<string, unknown> = {}) {
+  return { params: {}, query: {}, body: {}, ...overrides };
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.send = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /data/export', () => {
+  const handler = findHandler('get', '/data/export');
+
+  it('returns the current application data', () => {
+    mockedExportData.mockReturnValue({
+      schemaVersion: 1,
+      tasks: [],
+      blockers: [],
+      settings: {
+        staleThresholdHours: 48,
+        topN: 20,
+        oneTimeOffsetHours: 0,
+        oneTimeOffsetExpiresAt: null,
+        vacationPromptLastShownForUpdatedAt: null,
+        focusedTaskId: null,
+      },
+      nextTaskId: 1,
+      nextBlockerId: 1,
+    });
+
+    const res = mockRes();
+    handler(mockReq(), res);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ schemaVersion: 1 }));
+  });
+});
+
+describe('POST /data/snapshot', () => {
+  const handler = findHandler('post', '/data/snapshot');
+
+  it('creates a snapshot for the requested reason', () => {
+    mockedCreateDataSnapshot.mockReturnValue({
+      snapshotPath: '/tmp/backup.json',
+      createdAt: '2026-03-13T00:00:00.000Z',
+      reason: 'pre-update',
+    });
+
+    const res = mockRes();
+    handler(mockReq({ body: { reason: 'pre-update' } }), res);
+
+    expect(mockedCreateDataSnapshot).toHaveBeenCalledWith('pre-update');
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});
+
+describe('POST /data/import', () => {
+  const handler = findHandler('post', '/data/import');
+
+  it('returns import metadata after replacing the current data', () => {
+    mockedImportData.mockReturnValue({
+      data: {
+        schemaVersion: 1,
+        tasks: [{ id: 1, title: 'Imported', status: '', priority: 'P1', createdAt: '2026-03-13T00:00:00.000Z', updatedAt: '2026-03-13T00:00:00.000Z', completedAt: null, isArchived: false, hiddenUntilAt: null }],
+        blockers: [],
+        settings: {
+          staleThresholdHours: 48,
+          topN: 20,
+          oneTimeOffsetHours: 0,
+          oneTimeOffsetExpiresAt: null,
+          vacationPromptLastShownForUpdatedAt: null,
+          focusedTaskId: null,
+        },
+        nextTaskId: 2,
+        nextBlockerId: 1,
+      },
+      snapshot: {
+        snapshotPath: '/tmp/pre-import.json',
+        createdAt: '2026-03-13T00:00:00.000Z',
+        reason: 'pre-import',
+      },
+    });
+
+    const res = mockRes();
+    handler(mockReq({ body: { schemaVersion: 1, tasks: [], blockers: [], settings: {}, nextTaskId: 1, nextBlockerId: 1 } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      importedTaskCount: 1,
+      backupPath: '/tmp/pre-import.json',
+    }));
+  });
+});

--- a/server/__tests__/helpers.ts
+++ b/server/__tests__/helpers.ts
@@ -33,6 +33,7 @@ export function makeBlocker(overrides: Partial<Blocker> = {}): Blocker {
 
 export function makeAppData(overrides: Partial<AppData> = {}): AppData {
   return {
+    schemaVersion: 1,
     tasks: [],
     blockers: [],
     settings: {

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { readDataFromPaths, resolveStoragePaths } from '../storage.js';
+import { readDataFromPaths, resolveStoragePaths, writeFileAtomically } from '../storage.js';
 
 function makeAppData(title: string) {
   const now = '2026-02-24T00:00:00.000Z';
@@ -106,5 +106,20 @@ describe('storage migration pathing', () => {
 
     const data = readDataFromPaths(paths);
     expect(data.tasks[0].title).toBe('existing-target');
+  });
+});
+
+describe('atomic writes', () => {
+  it('replaces an existing file on win32-compatible paths', () => {
+    const tempRoot = fs.mkdtempSync(path.join(process.cwd(), 'tmp-atomic-write-'));
+    tempRoots.push(tempRoot);
+
+    const filePath = path.join(tempRoot, 'tasks.json');
+    fs.writeFileSync(filePath, JSON.stringify(makeAppData('before'), null, 2));
+
+    writeFileAtomically(filePath, JSON.stringify(makeAppData('after'), null, 2), 'win32');
+
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as ReturnType<typeof makeAppData>;
+    expect(parsed.tasks[0].title).toBe('after');
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -6,6 +6,7 @@ import { readDataFromPaths, resolveStoragePaths } from '../storage.js';
 function makeAppData(title: string) {
   const now = '2026-02-24T00:00:00.000Z';
   return {
+    schemaVersion: 1,
     tasks: [
       {
         id: 1,

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import type { Express } from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { taskRoutes } from './routes/tasks.js';
+import { blockerRoutes } from './routes/blockers.js';
+import { settingsRoutes } from './routes/settings.js';
+import { updateRoutes } from './routes/update.js';
+import { dataRoutes } from './routes/data.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PORT = 3001;
+const DEFAULT_HOST = '127.0.0.1';
+
+export interface CreateAppOptions {
+  distPath?: string;
+}
+
+export interface StartServerOptions extends CreateAppOptions {
+  host?: string;
+  port?: number;
+}
+
+function resolveProjectRoot(): string {
+  return __dirname.endsWith('server/dist') || __dirname.endsWith('server\\dist')
+    ? path.join(__dirname, '..', '..')
+    : path.join(__dirname, '..');
+}
+
+function resolveDistPath(distPath?: string): string {
+  if (distPath) return distPath;
+  return path.join(resolveProjectRoot(), 'dist');
+}
+
+export function createApp(options: CreateAppOptions = {}): Express {
+  const app = express();
+  const distPath = resolveDistPath(options.distPath);
+
+  app.use(express.json({ limit: '10mb' }));
+
+  app.use('/api', taskRoutes);
+  app.use('/api', blockerRoutes);
+  app.use('/api', settingsRoutes);
+  app.use('/api', dataRoutes);
+  app.use('/api', updateRoutes);
+
+  app.use(express.static(distPath));
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(distPath, 'index.html'));
+  });
+
+  return app;
+}
+
+export async function startServer(options: StartServerOptions = {}) {
+  const app = createApp({ distPath: options.distPath });
+  const host = options.host ?? process.env.HOST ?? DEFAULT_HOST;
+  const requestedPort = options.port ?? Number(process.env.PORT ?? DEFAULT_PORT);
+
+  const server = await new Promise<import('http').Server>((resolve, reject) => {
+    const nextServer = app.listen(requestedPort, host, () => resolve(nextServer));
+    nextServer.on('error', reject);
+  });
+
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : requestedPort;
+
+  return { app, server, host, port };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,35 +1,10 @@
-import express from 'express';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { taskRoutes } from './routes/tasks.js';
-import { blockerRoutes } from './routes/blockers.js';
-import { settingsRoutes } from './routes/settings.js';
-import { updateRoutes } from './routes/update.js';
+import { startServer } from './app.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const app = express();
-const PORT = 3001;
-
-app.use(express.json());
-
-// API routes
-app.use('/api', taskRoutes);
-app.use('/api', blockerRoutes);
-app.use('/api', settingsRoutes);
-app.use('/api', updateRoutes);
-
-// Serve static files in production (Vite build output is at project root /dist)
-// When running compiled JS from server/dist/, go up two levels to project root
-const projectRoot = __dirname.endsWith('server/dist') || __dirname.endsWith('server\\dist')
-  ? path.join(__dirname, '..', '..')
-  : path.join(__dirname, '..');
-const distPath = path.join(projectRoot, 'dist');
-
-app.use(express.static(distPath));
-app.get('*', (_req, res) => {
-  res.sendFile(path.join(distPath, 'index.html'));
-});
-
-app.listen(PORT, () => {
-  console.log(`Stradl running on http://localhost:${PORT}`);
-});
+try {
+  const { host, port } = await startServer();
+  console.log(`Stradl running on http://${host}:${port}`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'Failed to start Stradl.';
+  console.error(message);
+  process.exit(1);
+}

--- a/server/routes/data.ts
+++ b/server/routes/data.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { createDataSnapshot, exportData, importData } from '../storage.js';
+
+export const dataRoutes = Router();
+
+dataRoutes.get('/data/export', (_req, res) => {
+  res.json(exportData());
+});
+
+dataRoutes.post('/data/snapshot', (req, res) => {
+  try {
+    const requestedReason = req.body && typeof req.body.reason === 'string'
+      ? req.body.reason
+      : 'manual';
+    const snapshot = createDataSnapshot(requestedReason);
+    res.status(201).json(snapshot);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to create data snapshot.';
+    res.status(500).send(message);
+  }
+});
+
+dataRoutes.post('/data/import', (req, res) => {
+  try {
+    const result = importData(req.body);
+    res.status(201).json({
+      importedTaskCount: result.data.tasks.length,
+      importedBlockerCount: result.data.blockers.length,
+      backupPath: result.snapshot.snapshotPath,
+      backupCreatedAt: result.snapshot.createdAt,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to import data.';
+    res.status(400).send(message);
+  }
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -49,12 +49,27 @@ export interface Settings {
 }
 
 export interface AppData {
+  schemaVersion: number;
   tasks: Task[];
   blockers: Blocker[];
   settings: Settings;
   nextTaskId: number;
   nextBlockerId: number;
 }
+
+export interface DataSnapshot {
+  snapshotPath: string;
+  createdAt: string;
+  reason: string;
+}
+
+export interface ImportDataResult {
+  data: AppData;
+  snapshot: DataSnapshot;
+}
+
+export const CURRENT_SCHEMA_VERSION = 1;
+const SNAPSHOT_RETENTION_COUNT = 20;
 
 export function findProjectRoot(cwd = process.cwd()): string {
   const candidates = [
@@ -110,21 +125,64 @@ export function getDataFilePath(): string {
   return resolveStoragePaths().dataFile;
 }
 
+export function getBackupsDirectory(paths: StoragePaths = resolveStoragePaths()): string {
+  return path.join(paths.dataDir, 'backups');
+}
+
+function defaultSettings(): Settings {
+  return {
+    staleThresholdHours: 48,
+    topN: 20,
+    oneTimeOffsetHours: 0,
+    oneTimeOffsetExpiresAt: null,
+    vacationPromptLastShownForUpdatedAt: null,
+    focusedTaskId: null,
+  };
+}
+
 function defaultData(): AppData {
   return {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
     tasks: [],
     blockers: [],
-    settings: {
-      staleThresholdHours: 48,
-      topN: 20,
-      oneTimeOffsetHours: 0,
-      oneTimeOffsetExpiresAt: null,
-      vacationPromptLastShownForUpdatedAt: null,
-      focusedTaskId: null,
-    },
+    settings: defaultSettings(),
     nextTaskId: 1,
     nextBlockerId: 1,
   };
+}
+
+function writeFileAtomically(filePath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`
+  );
+
+  fs.writeFileSync(tempPath, contents);
+
+  const fileDescriptor = fs.openSync(tempPath, 'r');
+  try {
+    fs.fsyncSync(fileDescriptor);
+  } finally {
+    fs.closeSync(fileDescriptor);
+  }
+
+  fs.renameSync(tempPath, filePath);
+
+  try {
+    const dirDescriptor = fs.openSync(path.dirname(filePath), 'r');
+    try {
+      fs.fsyncSync(dirDescriptor);
+    } finally {
+      fs.closeSync(dirDescriptor);
+    }
+  } catch {
+    // Directory fsync is not supported on every platform/filesystem.
+  }
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  writeFileAtomically(filePath, JSON.stringify(value, null, 2));
 }
 
 function pickLatestLegacyDataFile(legacyDataFiles: string[]): string | null {
@@ -152,64 +210,230 @@ function ensureDataFile(paths: StoragePaths): void {
   }
 
   const data = defaultData();
-  fs.writeFileSync(paths.dataFile, JSON.stringify(data, null, 2));
+  writeJsonFile(paths.dataFile, data);
 }
 
-function normalizeData(parsed: AppData, dataFile: string): AppData {
-  let migrated = false;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
-  for (const task of parsed.tasks) {
-    if ('isDeleted' in task) {
-      if ((task as Record<string, unknown>).isDeleted) {
-        task.isArchived = true;
-      }
-      delete (task as Record<string, unknown>).isDeleted;
-      migrated = true;
-    }
+function isPriority(value: unknown): value is Task['priority'] {
+  return value === 'P0' || value === 'P1' || value === 'P2' || value === null;
+}
 
-    const hiddenUntilAt = (task as unknown as Record<string, unknown>).hiddenUntilAt;
-    if (hiddenUntilAt === undefined || (hiddenUntilAt !== null && typeof hiddenUntilAt !== 'string')) {
-      task.hiddenUntilAt = null;
-      migrated = true;
-    }
+function coerceTask(value: unknown, index: number): Task {
+  if (!isRecord(value)) {
+    throw new Error(`Task at index ${index} is invalid.`);
   }
 
-  if (migrated) {
-    fs.writeFileSync(dataFile, JSON.stringify(parsed, null, 2));
+  const fallbackNow = new Date().toISOString();
+  const createdAt = typeof value.createdAt === 'string' ? value.createdAt : fallbackNow;
+  const updatedAt = typeof value.updatedAt === 'string' ? value.updatedAt : createdAt;
+  const completedAt = typeof value.completedAt === 'string' ? value.completedAt : null;
+  const hiddenUntilAt = typeof value.hiddenUntilAt === 'string' ? value.hiddenUntilAt : null;
+  const isDeleted = typeof value.isDeleted === 'boolean' ? value.isDeleted : false;
+
+  if (
+    typeof value.id !== 'number' ||
+    !Number.isInteger(value.id) ||
+    typeof value.title !== 'string' ||
+    typeof value.status !== 'string'
+  ) {
+    throw new Error(`Task at index ${index} is missing required fields.`);
   }
 
-  const defaults = defaultData().settings;
-  const incoming = parsed.settings as Partial<Settings> | undefined;
+  return {
+    id: value.id,
+    title: value.title,
+    status: value.status,
+    priority: isPriority(value.priority) ? value.priority : null,
+    createdAt,
+    updatedAt,
+    completedAt,
+    isArchived: typeof value.isArchived === 'boolean' ? value.isArchived : isDeleted,
+    hiddenUntilAt,
+  };
+}
 
-  parsed.settings = {
-    staleThresholdHours: typeof incoming?.staleThresholdHours === 'number'
+function coerceBlocker(value: unknown, index: number): Blocker {
+  if (!isRecord(value)) {
+    throw new Error(`Blocker at index ${index} is invalid.`);
+  }
+
+  if (
+    typeof value.id !== 'number' ||
+    !Number.isInteger(value.id) ||
+    typeof value.taskId !== 'number' ||
+    !Number.isInteger(value.taskId)
+  ) {
+    throw new Error(`Blocker at index ${index} is missing required fields.`);
+  }
+
+  return {
+    id: value.id,
+    taskId: value.taskId,
+    blockedByTaskId: typeof value.blockedByTaskId === 'number' && Number.isInteger(value.blockedByTaskId)
+      ? value.blockedByTaskId
+      : null,
+    blockedUntilDate: typeof value.blockedUntilDate === 'string' ? value.blockedUntilDate : null,
+    resolved: value.resolved === true,
+  };
+}
+
+function coerceSettings(value: unknown): Settings {
+  const defaults = defaultSettings();
+  const incoming = isRecord(value) ? value : {};
+
+  return {
+    staleThresholdHours: typeof incoming.staleThresholdHours === 'number'
       ? incoming.staleThresholdHours
       : defaults.staleThresholdHours,
-    topN: typeof incoming?.topN === 'number'
+    topN: typeof incoming.topN === 'number'
       ? incoming.topN
       : defaults.topN,
-    oneTimeOffsetHours: typeof incoming?.oneTimeOffsetHours === 'number'
+    oneTimeOffsetHours: typeof incoming.oneTimeOffsetHours === 'number'
       ? incoming.oneTimeOffsetHours
       : defaults.oneTimeOffsetHours,
-    oneTimeOffsetExpiresAt: typeof incoming?.oneTimeOffsetExpiresAt === 'string'
+    oneTimeOffsetExpiresAt: typeof incoming.oneTimeOffsetExpiresAt === 'string'
       ? incoming.oneTimeOffsetExpiresAt
       : defaults.oneTimeOffsetExpiresAt,
-    vacationPromptLastShownForUpdatedAt: typeof incoming?.vacationPromptLastShownForUpdatedAt === 'string'
+    vacationPromptLastShownForUpdatedAt: typeof incoming.vacationPromptLastShownForUpdatedAt === 'string'
       ? incoming.vacationPromptLastShownForUpdatedAt
       : defaults.vacationPromptLastShownForUpdatedAt,
-    focusedTaskId: typeof incoming?.focusedTaskId === 'number'
+    focusedTaskId: typeof incoming.focusedTaskId === 'number' && Number.isInteger(incoming.focusedTaskId)
       ? incoming.focusedTaskId
       : defaults.focusedTaskId,
   };
+}
 
-  return parsed;
+function normalizeDataValue(parsed: unknown): { data: AppData; changed: boolean } {
+  if (!isRecord(parsed)) {
+    throw new Error('Data file root must be an object.');
+  }
+
+  let migrated = false;
+  const tasksRaw = parsed.tasks;
+  const blockersRaw = parsed.blockers;
+
+  if (!Array.isArray(tasksRaw) || !Array.isArray(blockersRaw)) {
+    throw new Error('Data file is missing tasks or blockers arrays.');
+  }
+
+  const tasks = tasksRaw.map((task, index) => {
+    if (isRecord(task) && ('isDeleted' in task || !('hiddenUntilAt' in task))) {
+      migrated = true;
+    }
+    return coerceTask(task, index);
+  });
+  const blockers = blockersRaw.map((blocker, index) => coerceBlocker(blocker, index));
+  const settings = coerceSettings(parsed.settings);
+
+  const maxTaskId = tasks.reduce((highest, task) => Math.max(highest, task.id), 0);
+  const maxBlockerId = blockers.reduce((highest, blocker) => Math.max(highest, blocker.id), 0);
+
+  const incomingSchemaVersion = parsed.schemaVersion;
+  if (incomingSchemaVersion !== CURRENT_SCHEMA_VERSION) {
+    migrated = true;
+  }
+
+  if (parsed.settings === undefined || !isRecord(parsed.settings)) {
+    migrated = true;
+  }
+
+  if (
+    typeof parsed.nextTaskId !== 'number' ||
+    !Number.isInteger(parsed.nextTaskId) ||
+    parsed.nextTaskId <= maxTaskId
+  ) {
+    migrated = true;
+  }
+
+  if (
+    typeof parsed.nextBlockerId !== 'number' ||
+    !Number.isInteger(parsed.nextBlockerId) ||
+    parsed.nextBlockerId <= maxBlockerId
+  ) {
+    migrated = true;
+  }
+
+  return {
+    data: {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      tasks,
+      blockers,
+      settings,
+      nextTaskId: typeof parsed.nextTaskId === 'number' && Number.isInteger(parsed.nextTaskId)
+        ? Math.max(parsed.nextTaskId, maxTaskId + 1)
+        : maxTaskId + 1,
+      nextBlockerId: typeof parsed.nextBlockerId === 'number' && Number.isInteger(parsed.nextBlockerId)
+        ? Math.max(parsed.nextBlockerId, maxBlockerId + 1)
+        : maxBlockerId + 1,
+    },
+    changed: migrated,
+  };
+}
+
+function normalizeData(parsed: unknown, dataFile: string): AppData {
+  const normalized = normalizeDataValue(parsed);
+  if (normalized.changed) {
+    writeJsonFile(dataFile, normalized.data);
+  }
+  return normalized.data;
+}
+
+export function parseAppData(value: unknown): AppData {
+  return normalizeDataValue(value).data;
+}
+
+function sanitizeSnapshotReason(reason: string): string {
+  const sanitized = reason.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return sanitized || 'snapshot';
+}
+
+function pruneSnapshots(paths: StoragePaths, keep = SNAPSHOT_RETENTION_COUNT): void {
+  const backupsDir = getBackupsDirectory(paths);
+  if (!fs.existsSync(backupsDir)) return;
+
+  const entries = fs.readdirSync(backupsDir)
+    .map((name) => {
+      const entryPath = path.join(backupsDir, name);
+      const stats = fs.statSync(entryPath);
+      return { name, entryPath, mtimeMs: stats.mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const entry of entries.slice(keep)) {
+    fs.rmSync(entry.entryPath, { recursive: true, force: true });
+  }
+}
+
+export function createDataSnapshot(
+  reason: string,
+  paths: StoragePaths = resolveStoragePaths()
+): DataSnapshot {
+  ensureDataFile(paths);
+  const data = readDataFromPaths(paths);
+  const createdAt = new Date().toISOString();
+  const backupsDir = getBackupsDirectory(paths);
+  fs.mkdirSync(backupsDir, { recursive: true });
+
+  const fileName = `${createdAt.replace(/[:.]/g, '-')}-${sanitizeSnapshotReason(reason)}.json`;
+  const snapshotPath = path.join(backupsDir, fileName);
+  writeJsonFile(snapshotPath, data);
+  pruneSnapshots(paths);
+
+  return {
+    snapshotPath,
+    createdAt,
+    reason,
+  };
 }
 
 export function readDataFromPaths(paths: StoragePaths): AppData {
   ensureDataFile(paths);
 
   const raw = fs.readFileSync(paths.dataFile, 'utf-8');
-  const parsed = JSON.parse(raw) as AppData;
+  const parsed = JSON.parse(raw) as unknown;
   return normalizeData(parsed, paths.dataFile);
 }
 
@@ -218,12 +442,27 @@ export function readData(): AppData {
 }
 
 export function writeDataToPaths(data: AppData, paths: StoragePaths): void {
-  if (!fs.existsSync(paths.dataDir)) {
-    fs.mkdirSync(paths.dataDir, { recursive: true });
-  }
-  fs.writeFileSync(paths.dataFile, JSON.stringify(data, null, 2));
+  const normalized = parseAppData(data);
+  writeJsonFile(paths.dataFile, normalized);
 }
 
 export function writeData(data: AppData): void {
   writeDataToPaths(data, resolveStoragePaths());
+}
+
+export function exportData(paths: StoragePaths = resolveStoragePaths()): AppData {
+  return readDataFromPaths(paths);
+}
+
+export function importData(
+  value: unknown,
+  paths: StoragePaths = resolveStoragePaths()
+): ImportDataResult {
+  const snapshot = createDataSnapshot('pre-import', paths);
+  const normalized = parseAppData(value);
+  writeDataToPaths(normalized, paths);
+  return {
+    data: normalized,
+    snapshot,
+  };
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -151,7 +151,38 @@ function defaultData(): AppData {
   };
 }
 
-function writeFileAtomically(filePath: string, contents: string): void {
+function replaceFile(
+  tempPath: string,
+  filePath: string,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform !== 'win32' || !fs.existsSync(filePath)) {
+    fs.renameSync(tempPath, filePath);
+    return;
+  }
+
+  const backupPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.bak`
+  );
+
+  fs.renameSync(filePath, backupPath);
+  try {
+    fs.renameSync(tempPath, filePath);
+    fs.rmSync(backupPath, { force: true });
+  } catch (error) {
+    if (!fs.existsSync(filePath) && fs.existsSync(backupPath)) {
+      fs.renameSync(backupPath, filePath);
+    }
+    throw error;
+  }
+}
+
+export function writeFileAtomically(
+  filePath: string,
+  contents: string,
+  platform: NodeJS.Platform = process.platform
+): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tempPath = path.join(
     path.dirname(filePath),
@@ -167,7 +198,7 @@ function writeFileAtomically(filePath: string, contents: string): void {
     fs.closeSync(fileDescriptor);
   }
 
-  fs.renameSync(tempPath, filePath);
+  replaceFile(tempPath, filePath, platform);
 
   try {
     const dirDescriptor = fs.openSync(path.dirname(filePath), 'r');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -492,7 +492,6 @@ export default function App() {
     } catch (error) {
       const message = `Failed to export tasks: ${getErrorMessage(error)}`;
       showToast(message, 'error');
-      throw new Error(message);
     } finally {
       setIsExportingData(false);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import type { TabName, Task, Settings } from './types';
+import type { TabName, Task, Settings, RuntimeInfo, StoredAppData } from './types';
 import { useTasks } from './hooks/useTasks';
 import { useSettings } from './hooks/useSettings';
 import { useBlockers } from './hooks/useBlockers';
@@ -56,6 +56,9 @@ export default function App() {
   const [vacationInactivityDays, setVacationInactivityDays] = useState(1);
   const [vacationAnchorUpdatedAt, setVacationAnchorUpdatedAt] = useState<string | null>(null);
   const [vacationNudgeSaving, setVacationNudgeSaving] = useState(false);
+  const [runtimeInfo, setRuntimeInfo] = useState<RuntimeInfo | null>(null);
+  const [isExportingData, setIsExportingData] = useState(false);
+  const [isImportingData, setIsImportingData] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     const saved = localStorage.getItem('stradl-theme');
     if (saved === 'dark' || saved === 'light') return saved;
@@ -133,8 +136,34 @@ export default function App() {
   }, [toasts, dismissToast]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const info = await api.fetchRuntimeInfo();
+        if (!cancelled) {
+          setRuntimeInfo(info);
+        }
+      } catch {
+        if (!cancelled) {
+          setRuntimeInfo({
+            mode: 'web',
+            appVersion: 'web',
+            canSelfUpdate: false,
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!runtimeInfo?.canSelfUpdate) return;
     void maybeAutoCheck();
-  }, [maybeAutoCheck]);
+  }, [maybeAutoCheck, runtimeInfo?.canSelfUpdate]);
 
   useEffect(() => {
     if (!updateCheckResult?.hasUpdate) return;
@@ -403,6 +432,16 @@ export default function App() {
     if (handledUpdateSuccessRef.current === successKey) return;
     handledUpdateSuccessRef.current = successKey;
 
+    if (runtimeInfo?.mode === 'desktop-local') {
+      showToast(
+        updateApplyStatus.toVersion
+          ? `Update applied. Running v${updateApplyStatus.toVersion}.`
+          : 'Update applied successfully.',
+        'success'
+      );
+      return;
+    }
+
     let cancelled = false;
     void (async () => {
       showToast('Update applied. Reloading latest version...', 'success');
@@ -431,7 +470,54 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [showToast, updateApplyStatus]);
+  }, [runtimeInfo?.mode, showToast, updateApplyStatus]);
+
+  const handleExportData = useCallback(async () => {
+    if (isExportingData) return;
+
+    setIsExportingData(true);
+    try {
+      const data = await api.exportData();
+      const contents = JSON.stringify(data, null, 2);
+      const blob = new Blob([contents], { type: 'application/json' });
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `stradl-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+      showToast('Backup exported.', 'success');
+    } catch (error) {
+      const message = `Failed to export tasks: ${getErrorMessage(error)}`;
+      showToast(message, 'error');
+      throw new Error(message);
+    } finally {
+      setIsExportingData(false);
+    }
+  }, [isExportingData, showToast]);
+
+  const handleImportData = useCallback(async (data: StoredAppData) => {
+    if (isImportingData) return;
+
+    setIsImportingData(true);
+    try {
+      const result = await api.importData(data);
+      await Promise.all([reload(), reloadSettings(), loadCounts()]);
+      setSearchQuery('');
+      showToast(
+        `Imported ${result.importedTaskCount} tasks. Backup saved to ${result.backupPath}.`,
+        'success'
+      );
+    } catch (error) {
+      const message = `Failed to import tasks: ${getErrorMessage(error)}`;
+      showToast(message, 'error');
+      throw new Error(message);
+    } finally {
+      setIsImportingData(false);
+    }
+  }, [isImportingData, loadCounts, reload, reloadSettings, showToast]);
 
   const handleApplyVacationNudge = async (days: number) => {
     if (!vacationAnchorUpdatedAt) return;
@@ -554,6 +640,7 @@ export default function App() {
           <SettingsPanel
             settings={settings}
             onSave={handleSaveSettings}
+            runtimeInfo={runtimeInfo}
             updateCheckResult={updateCheckResult}
             updateCheckError={updateCheckError}
             updateLastCheckedAt={updateLastCheckedAt}
@@ -563,6 +650,10 @@ export default function App() {
             updateApplyError={updateApplyError}
             isApplyingUpdate={isApplyingUpdate}
             onApplyUpdate={handleApplyUpdate}
+            isExportingData={isExportingData}
+            isImportingData={isImportingData}
+            onExportData={handleExportData}
+            onImportData={handleImportData}
           />
         </div>
       </header>

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,12 +3,21 @@ import type {
   Blocker,
   Settings,
   TabName,
+  RuntimeInfo,
+  StoredAppData,
   UpdateCheckResult,
   UpdateApplyStartResult,
   UpdateApplyStatus,
+  DataSnapshotResult,
+  DataImportResult,
 } from './types';
 
 const BASE = '/api';
+
+function getDesktopApi() {
+  if (typeof window === 'undefined') return null;
+  return window.stradlDesktop ?? null;
+}
 
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(BASE + url, {
@@ -76,12 +85,48 @@ export const fetchSettings = () =>
 export const updateSettings = (data: Partial<Settings>) =>
   request<Settings>('/settings', { method: 'PUT', body: JSON.stringify(data) });
 
+// Runtime
+export const fetchRuntimeInfo = async (): Promise<RuntimeInfo> => {
+  const desktopApi = getDesktopApi();
+  if (desktopApi) {
+    return desktopApi.getRuntimeInfo();
+  }
+
+  return {
+    mode: 'web',
+    appVersion: 'web',
+    canSelfUpdate: false,
+  };
+};
+
 // Updates
 export const checkForUpdates = () =>
-  request<UpdateCheckResult>('/update-check');
+  getDesktopApi()
+    ? getDesktopApi()!.checkForUpdates()
+    : request<UpdateCheckResult>('/update-check');
 
 export const applyUpdate = () =>
-  request<UpdateApplyStartResult>('/update-apply', { method: 'POST' });
+  getDesktopApi()
+    ? getDesktopApi()!.applyUpdate()
+    : request<UpdateApplyStartResult>('/update-apply', { method: 'POST' });
 
 export const fetchUpdateApplyStatus = () =>
-  request<UpdateApplyStatus>('/update-apply-status');
+  getDesktopApi()
+    ? getDesktopApi()!.getUpdateStatus()
+    : request<UpdateApplyStatus>('/update-apply-status');
+
+// Data portability
+export const exportData = () =>
+  request<StoredAppData>('/data/export');
+
+export const createDataSnapshot = (reason: string) =>
+  request<DataSnapshotResult>('/data/snapshot', {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  });
+
+export const importData = (data: StoredAppData) =>
+  request<DataImportResult>('/data/import', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });

--- a/src/api.ts
+++ b/src/api.ts
@@ -100,20 +100,26 @@ export const fetchRuntimeInfo = async (): Promise<RuntimeInfo> => {
 };
 
 // Updates
-export const checkForUpdates = () =>
-  getDesktopApi()
-    ? getDesktopApi()!.checkForUpdates()
+export const checkForUpdates = () => {
+  const desktopApi = getDesktopApi();
+  return desktopApi
+    ? desktopApi.checkForUpdates()
     : request<UpdateCheckResult>('/update-check');
+};
 
-export const applyUpdate = () =>
-  getDesktopApi()
-    ? getDesktopApi()!.applyUpdate()
+export const applyUpdate = () => {
+  const desktopApi = getDesktopApi();
+  return desktopApi
+    ? desktopApi.applyUpdate()
     : request<UpdateApplyStartResult>('/update-apply', { method: 'POST' });
+};
 
-export const fetchUpdateApplyStatus = () =>
-  getDesktopApi()
-    ? getDesktopApi()!.getUpdateStatus()
+export const fetchUpdateApplyStatus = () => {
+  const desktopApi = getDesktopApi();
+  return desktopApi
+    ? desktopApi.getUpdateStatus()
     : request<UpdateApplyStatus>('/update-apply-status');
+};
 
 // Data portability
 export const exportData = () =>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,9 +1,16 @@
 import { useState, useRef, useEffect } from 'react';
-import type { Settings, UpdateCheckResult, UpdateApplyStatus } from '../types';
+import type {
+  Settings,
+  RuntimeInfo,
+  StoredAppData,
+  UpdateCheckResult,
+  UpdateApplyStatus,
+} from '../types';
 
 interface Props {
   settings: Settings;
   onSave: (data: Partial<Settings>) => Promise<void>;
+  runtimeInfo: RuntimeInfo | null;
   updateCheckResult: UpdateCheckResult | null;
   updateCheckError: string | null;
   updateLastCheckedAt: string | null;
@@ -13,6 +20,10 @@ interface Props {
   updateApplyError: string | null;
   isApplyingUpdate: boolean;
   onApplyUpdate: () => Promise<void>;
+  isExportingData: boolean;
+  isImportingData: boolean;
+  onExportData: () => Promise<void>;
+  onImportData: (data: StoredAppData) => Promise<void>;
 }
 
 interface SettingsDraft {
@@ -35,6 +46,7 @@ function toDraft(settings: Settings): SettingsDraft {
 export default function SettingsPanel({
   settings,
   onSave,
+  runtimeInfo,
   updateCheckResult,
   updateCheckError,
   updateLastCheckedAt,
@@ -44,13 +56,19 @@ export default function SettingsPanel({
   updateApplyError,
   isApplyingUpdate,
   onApplyUpdate,
+  isExportingData,
+  isImportingData,
+  onExportData,
+  onImportData,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [draft, setDraft] = useState<SettingsDraft>(toDraft(settings));
   const [errors, setErrors] = useState<SettingsErrors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [dataTransferError, setDataTransferError] = useState<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -70,6 +88,7 @@ export default function SettingsPanel({
     setDraft(toDraft(settings));
     setErrors({});
     setSubmitError(null);
+    setDataTransferError(null);
   }, [settings, open]);
 
   const validate = (): { nextSettings: Partial<Settings> | null; nextErrors: SettingsErrors } => {
@@ -130,11 +149,15 @@ export default function SettingsPanel({
     setOpen(false);
   };
 
-  const updateStatus = updateCheckResult == null
-    ? 'Check for updates to see the latest available release.'
-    : updateCheckResult.hasUpdate
-      ? `Update available: v${updateCheckResult.latestVersion}.`
-      : `You're up to date (v${updateCheckResult.currentVersion}).`;
+  const isDesktopRuntime = runtimeInfo?.mode === 'desktop-local';
+
+  const updateStatus = !isDesktopRuntime
+    ? 'Desktop self-update is available in the packaged app.'
+    : updateCheckResult == null
+      ? 'Check for updates to see the latest available release.'
+      : updateCheckResult.hasUpdate
+        ? `Update available: v${updateCheckResult.latestVersion}.`
+        : `You're up to date (v${updateCheckResult.currentVersion}).`;
 
   const applyStatus = updateApplyStatus == null
     ? null
@@ -145,6 +168,27 @@ export default function SettingsPanel({
         : updateApplyStatus.state === 'failed'
           ? 'Update failed.'
           : null;
+
+  const handleImportSelection = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || isImportingData) return;
+
+    setDataTransferError(null);
+
+    try {
+      const raw = await file.text();
+      const parsed = JSON.parse(raw) as StoredAppData;
+      const confirmed = window.confirm(
+        'Importing replaces the current tasks file. A backup will be created automatically first. Continue?'
+      );
+      if (!confirmed) return;
+
+      await onImportData(parsed);
+      event.target.value = '';
+    } catch (error) {
+      setDataTransferError(error instanceof Error ? error.message : 'Failed to import data.');
+    }
+  };
 
   return (
     <div className="settings-panel" ref={panelRef}>
@@ -183,7 +227,10 @@ export default function SettingsPanel({
           <div className="settings-updates-section">
             <h3 className="settings-updates-title">App Updates</h3>
             <p className="settings-help">
-              Current version: <strong>{updateCheckResult?.currentVersion || 'Unknown'}</strong>
+              Runtime: <strong>{isDesktopRuntime ? 'Desktop app' : 'Web/PWA'}</strong>
+            </p>
+            <p className="settings-help">
+              Current version: <strong>{runtimeInfo?.appVersion || updateCheckResult?.currentVersion || 'Unknown'}</strong>
             </p>
             <p className="settings-help">
               Latest version: <strong>{updateCheckResult?.latestVersion || 'Unknown'}</strong>
@@ -204,11 +251,11 @@ export default function SettingsPanel({
               <button
                 className="btn btn-sm"
                 onClick={() => { void onCheckForUpdates(); }}
-                disabled={saving || isCheckingUpdates || isApplyingUpdate}
+                disabled={saving || isCheckingUpdates || isApplyingUpdate || !isDesktopRuntime}
               >
                 {isCheckingUpdates ? 'Checking...' : 'Check for updates'}
               </button>
-              {updateCheckResult?.hasUpdate && (
+              {isDesktopRuntime && updateCheckResult?.hasUpdate && (
                 <button
                   className="btn btn-sm btn-primary"
                   onClick={() => { void onApplyUpdate(); }}
@@ -217,7 +264,7 @@ export default function SettingsPanel({
                   {isApplyingUpdate ? 'Applying...' : 'Update now'}
                 </button>
               )}
-              {updateCheckResult?.hasUpdate && (
+              {isDesktopRuntime && updateCheckResult?.hasUpdate && (
                 <a
                   className="btn btn-sm"
                   href={updateCheckResult.releaseUrl}
@@ -227,6 +274,37 @@ export default function SettingsPanel({
                   View release notes
                 </a>
               )}
+            </div>
+          </div>
+
+          <div className="settings-updates-section">
+            <h3 className="settings-updates-title">Task Backup & Move</h3>
+            <p className="settings-help">
+              Export a full JSON backup before switching installs or machines. Import replaces the current task file after creating an automatic backup.
+            </p>
+            {dataTransferError && <p className="settings-error">{dataTransferError}</p>}
+            <div className="settings-update-actions">
+              <button
+                className="btn btn-sm"
+                onClick={() => { void onExportData(); }}
+                disabled={saving || isExportingData || isImportingData}
+              >
+                {isExportingData ? 'Exporting...' : 'Export tasks'}
+              </button>
+              <button
+                className="btn btn-sm"
+                onClick={() => importInputRef.current?.click()}
+                disabled={saving || isExportingData || isImportingData}
+              >
+                {isImportingData ? 'Importing...' : 'Import tasks'}
+              </button>
+              <input
+                ref={importInputRef}
+                type="file"
+                accept="application/json,.json"
+                style={{ display: 'none' }}
+                onChange={(event) => { void handleImportSelection(event); }}
+              />
             </div>
           </div>
 

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import type { ChangeEvent } from 'react';
 import type {
   Settings,
   RuntimeInfo,
@@ -150,9 +151,12 @@ export default function SettingsPanel({
   };
 
   const isDesktopRuntime = runtimeInfo?.mode === 'desktop-local';
+  const canSelfUpdate = runtimeInfo?.canSelfUpdate === true;
 
   const updateStatus = !isDesktopRuntime
     ? 'Desktop self-update is available in the packaged app.'
+    : !canSelfUpdate
+      ? 'Self-update is unavailable until the packaged app is installed in ~/Applications.'
     : updateCheckResult == null
       ? 'Check for updates to see the latest available release.'
       : updateCheckResult.hasUpdate
@@ -169,7 +173,7 @@ export default function SettingsPanel({
           ? 'Update failed.'
           : null;
 
-  const handleImportSelection = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImportSelection = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file || isImportingData) return;
 
@@ -259,7 +263,7 @@ export default function SettingsPanel({
                 <button
                   className="btn btn-sm btn-primary"
                   onClick={() => { void onApplyUpdate(); }}
-                  disabled={saving || isApplyingUpdate}
+                  disabled={saving || isApplyingUpdate || !canSelfUpdate}
                 >
                   {isApplyingUpdate ? 'Applying...' : 'Update now'}
                 </button>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,0 +1,20 @@
+import type {
+  RuntimeInfo,
+  UpdateCheckResult,
+  UpdateApplyStartResult,
+  UpdateApplyStatus,
+} from './types';
+
+declare global {
+  interface Window {
+    stradlDesktop?: {
+      getRuntimeInfo: () => Promise<RuntimeInfo>;
+      checkForUpdates: () => Promise<UpdateCheckResult>;
+      applyUpdate: () => Promise<UpdateApplyStartResult>;
+      getUpdateStatus: () => Promise<UpdateApplyStatus>;
+      onUpdateStatus?: (listener: (status: UpdateApplyStatus) => void) => (() => void);
+    };
+  }
+}
+
+export {};

--- a/src/hooks/useApplyUpdate.ts
+++ b/src/hooks/useApplyUpdate.ts
@@ -33,6 +33,20 @@ export function useApplyUpdate() {
   }, []);
 
   useEffect(() => {
+    void refreshStatus({ suppressError: true }).catch(() => undefined);
+  }, [refreshStatus]);
+
+  useEffect(() => {
+    const desktopApi = window.stradlDesktop;
+    if (!desktopApi?.onUpdateStatus) return;
+
+    return desktopApi.onUpdateStatus((next) => {
+      setStatus(next);
+      setError(null);
+    });
+  }, []);
+
+  useEffect(() => {
     if (status?.state !== 'running') return;
 
     const timer = window.setInterval(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,21 @@ export interface Settings {
   focusedTaskId: number | null;
 }
 
+export interface StoredAppData {
+  schemaVersion: number;
+  tasks: Task[];
+  blockers: Blocker[];
+  settings: Settings;
+  nextTaskId: number;
+  nextBlockerId: number;
+}
+
+export interface RuntimeInfo {
+  mode: 'desktop-local' | 'web';
+  appVersion: string;
+  canSelfUpdate: boolean;
+}
+
 export interface UpdateCheckResult {
   currentVersion: string;
   latestVersion: string;
@@ -54,6 +69,19 @@ export interface UpdateApplyStatus {
   finishedAt?: string;
   fromVersion?: string;
   toVersion?: string;
+}
+
+export interface DataSnapshotResult {
+  snapshotPath: string;
+  createdAt: string;
+  reason: string;
+}
+
+export interface DataImportResult {
+  importedTaskCount: number;
+  importedBlockerCount: number;
+  backupPath: string;
+  backupCreatedAt: string;
 }
 
 export type TabName = 'tasks' | 'backlog' | 'ideas' | 'blocked' | 'hidden' | 'completed' | 'archive';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,32 +2,42 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
-export default defineConfig({
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      manifest: {
-        name: 'Stradl',
-        short_name: 'Stradl',
-        description: 'Local task management with priorities and blockers',
-        theme_color: '#2563eb',
-        background_color: '#f9fafb',
-        display: 'standalone',
-        icons: [
-          { src: '/icon-192.svg', sizes: '192x192', type: 'image/svg+xml' },
-          { src: '/icon-512.svg', sizes: '512x512', type: 'image/svg+xml' },
-        ],
-      },
-    }),
-  ],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const isDesktopBuild = mode === 'desktop';
+
+  return {
+    plugins: [
+      react(),
+      ...(
+        isDesktopBuild
+          ? []
+          : [
+              VitePWA({
+                registerType: 'autoUpdate',
+                manifest: {
+                  name: 'Stradl',
+                  short_name: 'Stradl',
+                  description: 'Local task management with priorities and blockers',
+                  theme_color: '#2563eb',
+                  background_color: '#f9fafb',
+                  display: 'standalone',
+                  icons: [
+                    { src: '/icon-192.svg', sizes: '192x192', type: 'image/svg+xml' },
+                    { src: '/icon-512.svg', sizes: '512x512', type: 'image/svg+xml' },
+                  ],
+                },
+              }),
+            ]
+      ),
+    ],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3001',
+          changeOrigin: true,
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary
- add an Electron-based packaged macOS runtime that embeds the existing Express API and owns desktop self-update
- harden task persistence with schema versioning, atomic writes, snapshots, and explicit export/import endpoints so data survives migration and future upgrades
- extend the release pipeline to build desktop artifacts, generate SHA256 checksums, and upload the packaged app assets required by the updater

## Testing
- npm test
- npm run typecheck
- npm run build
- npm run build:desktop
- npm run package:desktop

## Notes
- desktop packaging was verified by producing the macOS zip artifact and SHA256SUMS.txt
- the desktop build is currently unsigned and the packaging run in this environment produced the host-arch macOS artifact (arm64)