### PR TITLE
Add optional status field to task creation form

### DIFF
--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -10,6 +10,8 @@ interface Props {
 
 export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) {
   const [title, setTitle] = useState('');
+  const [status, setStatus] = useState('');
+  const [showStatus, setShowStatus] = useState(false);
   const [priority, setPriority] = useState<string>('P1');
   const [submitting, setSubmitting] = useState(false);
 
@@ -22,9 +24,12 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
     try {
       await onCreate({
         title: title.trim(),
+        ...(status.trim() ? { status: status.trim() } : {}),
         priority: isIdea ? null : priority,
       });
       setTitle('');
+      setStatus('');
+      setShowStatus(false);
     } catch {
       // Error feedback is handled at the app level.
     } finally {
@@ -34,32 +39,54 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
 
   return (
     <form className="task-form" onSubmit={handleSubmit}>
-      <input
-        ref={titleInputRef}
-        type="text"
-        placeholder={activeTab === 'ideas' ? 'New idea...' : 'New task... (press / to focus)'}
-        value={title}
-        onChange={e => setTitle(e.target.value)}
-        className="task-form-input"
-        aria-label={activeTab === 'ideas' ? 'New idea title' : 'New task title'}
-        disabled={submitting}
-      />
-      {activeTab !== 'ideas' && (
-        <select
-          value={priority}
-          onChange={e => setPriority(e.target.value)}
-          className="task-form-priority"
-          aria-label="New task priority"
+      <div className="task-form-row">
+        <input
+          ref={titleInputRef}
+          type="text"
+          placeholder={activeTab === 'ideas' ? 'New idea...' : 'New task... (press / to focus)'}
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="task-form-input"
+          aria-label={activeTab === 'ideas' ? 'New idea title' : 'New task title'}
           disabled={submitting}
+        />
+        {activeTab !== 'ideas' && (
+          <select
+            value={priority}
+            onChange={e => setPriority(e.target.value)}
+            className="task-form-priority"
+            aria-label="New task priority"
+            disabled={submitting}
+          >
+            <option value="P0">P0</option>
+            <option value="P1">P1</option>
+            <option value="P2">P2</option>
+          </select>
+        )}
+        <button
+          type="button"
+          className={`btn task-form-status-toggle${showStatus ? ' active' : ''}`}
+          onClick={() => setShowStatus(!showStatus)}
+          title={showStatus ? 'Hide status' : 'Add status'}
+          aria-label={showStatus ? 'Hide status field' : 'Show status field'}
         >
-          <option value="P0">P0</option>
-          <option value="P1">P1</option>
-          <option value="P2">P2</option>
-        </select>
+          +Status
+        </button>
+        <button type="submit" className="btn btn-primary" disabled={submitting}>
+          {submitting ? 'Adding...' : 'Add'}
+        </button>
+      </div>
+      {showStatus && (
+        <textarea
+          placeholder="Status / description..."
+          value={status}
+          onChange={e => setStatus(e.target.value)}
+          className="task-form-status"
+          aria-label="New task status"
+          disabled={submitting}
+          rows={2}
+        />
       )}
-      <button type="submit" className="btn btn-primary" disabled={submitting}>
-        {submitting ? 'Adding...' : 'Add'}
-      </button>
     </form>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -230,8 +230,14 @@ textarea:focus-visible,
 /* Task Form */
 .task-form {
   display: flex;
+  flex-direction: column;
   gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.task-form-row {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .task-form-input {
@@ -261,6 +267,39 @@ textarea:focus-visible,
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
+}
+
+.task-form-status-toggle {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+
+.task-form-status-toggle.active {
+  color: var(--blue-600);
+  border-color: var(--blue-600);
+}
+
+.task-form-status {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-default);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  resize: vertical;
+}
+
+.task-form-status::placeholder {
+  color: var(--text-muted);
+}
+
+.task-form-status:focus {
+  outline: none;
+  border-color: var(--blue-600);
+  box-shadow: 0 0 0 2px var(--blue-ring);
 }
 
 /* Buttons */
@@ -1038,7 +1077,7 @@ textarea:focus-visible,
     min-height: 36px;
   }
 
-  .task-form {
+  .task-form-row {
     flex-direction: column;
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
       port: 5173,
       proxy: {
         '/api': {
-          target: 'http://localhost:3001',
+          target: 'http://127.0.0.1:3001',
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
## Summary
- Add a toggleable "+Status" button to the task creation form that reveals a textarea for entering an initial status/description when creating a task
- Form stays compact by default; status field appears below the title row when toggled
- Fix Vite dev proxy IPv4/IPv6 mismatch (`localhost` → `127.0.0.1`) that caused connection refused errors

## Test plan
- [x] Create a task without clicking "+Status" — should work as before
- [x] Click "+Status", enter a description, create the task — status should be saved
- [x] Verify the status field collapses and clears after submission
- [x] Test on mobile viewport — form row should stack vertically
- [x] Verify dev server proxy works (`npm run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)