### PR TITLE
Polish task row interactions

### DIFF
--- a/server/__tests__/blocker-routes.test.ts
+++ b/server/__tests__/blocker-routes.test.ts
@@ -123,6 +123,17 @@ describe('POST /tasks/:id/blockers', () => {
     expect(res.json.mock.calls[0][0].blockedUntilDate).toBe('2025-06-01T00:00:00Z');
   });
 
+  it('touches updatedAt when adding a blocker', () => {
+    const task = makeTask({ id: 1, updatedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: {} }), res);
+
+    expect(task.updatedAt).not.toBe('2024-01-01T00:00:00Z');
+  });
+
   it('increments nextBlockerId', () => {
     const data = makeAppData({ tasks: [makeTask({ id: 1 })], nextBlockerId: 10 });
     mockedReadData.mockReturnValue(data);

--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -176,6 +176,22 @@ describe('GET /tasks', () => {
     expect(res.json.mock.calls[0][0][0].id).toBe(1);
   });
 
+  it('sorts hidden tasks by earliest unhide time first', () => {
+    const data = makeAppData({
+      tasks: [
+        makeTask({ id: 1, hiddenUntilAt: '2099-01-03T12:00:00Z', updatedAt: '2024-03-01T00:00:00Z' }),
+        makeTask({ id: 2, hiddenUntilAt: '2099-01-01T12:00:00Z', updatedAt: '2024-02-01T00:00:00Z' }),
+        makeTask({ id: 3, hiddenUntilAt: '2099-01-02T12:00:00Z', updatedAt: '2024-01-01T00:00:00Z' }),
+      ],
+    });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ query: { tab: 'hidden' } }), res);
+
+    expect(res.json.mock.calls[0][0].map((task: any) => task.id)).toEqual([2, 3, 1]);
+  });
+
   it('excludes expired hidden tasks from hidden tab', () => {
     const data = makeAppData({
       tasks: [makeTask({ id: 1, hiddenUntilAt: '2020-01-01T00:00:00Z' })],
@@ -476,6 +492,17 @@ describe('PUT /tasks/:id', () => {
     expect(res.json.mock.calls[0][0].isArchived).toBe(true);
   });
 
+  it('touches updatedAt when archiving', () => {
+    const task = makeTask({ id: 1, isArchived: false, updatedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { isArchived: true } }), res);
+
+    expect(res.json.mock.calls[0][0].updatedAt).not.toBe('2024-01-01T00:00:00Z');
+  });
+
   it('clears hiddenUntilAt and focusedTaskId when archiving', () => {
     const task = makeTask({ id: 1, isArchived: false, hiddenUntilAt: '2099-01-01T00:00:00Z' });
     const data = makeAppData({
@@ -639,6 +666,17 @@ describe('POST /tasks/:id/hide', () => {
     expect(res.json.mock.calls[0][0].hiddenUntilAt).not.toBeNull();
   });
 
+  it('touches updatedAt when hiding a task', () => {
+    const task = makeTask({ id: 1, priority: 'P1', hiddenUntilAt: null, updatedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' }, body: { durationMinutes: 30 } }), res);
+
+    expect(res.json.mock.calls[0][0].updatedAt).not.toBe('2024-01-01T00:00:00Z');
+  });
+
   it('rejects invalid durations', () => {
     const task = makeTask({ id: 1, priority: 'P1' });
     const data = makeAppData({ tasks: [task] });
@@ -720,6 +758,17 @@ describe('POST /tasks/:id/focus', () => {
     handler(mockReq({ params: { id: '1' } }), res);
 
     expect(data.settings.focusedTaskId).toBe(1);
+  });
+
+  it('touches updatedAt when focusing a task', () => {
+    const task = makeTask({ id: 1, priority: 'P1', hiddenUntilAt: null, updatedAt: '2024-01-01T00:00:00Z' });
+    const data = makeAppData({ tasks: [task] });
+    mockedReadData.mockReturnValue(data);
+    const res = mockRes();
+
+    handler(mockReq({ params: { id: '1' } }), res);
+
+    expect(task.updatedAt).not.toBe('2024-01-01T00:00:00Z');
   });
 
   it('replaces previous focusedTaskId', () => {

--- a/server/routes/blockers.ts
+++ b/server/routes/blockers.ts
@@ -33,6 +33,7 @@ blockerRoutes.post('/tasks/:id/blockers', (req, res) => {
   };
 
   data.blockers.push(blocker);
+  task.updatedAt = new Date().toISOString();
   if (data.settings.focusedTaskId === taskId) {
     data.settings.focusedTaskId = null;
   }

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -31,6 +31,12 @@ function clearInvalidFocus(data: AppData, now = new Date()): boolean {
   return false;
 }
 
+function touchTask(task: Task): string {
+  const now = new Date().toISOString();
+  task.updatedAt = now;
+  return now;
+}
+
 // GET /api/tasks?tab=tasks|backlog|ideas|blocked|hidden|completed|archive
 taskRoutes.get('/tasks', (req, res) => {
   const data = readData();
@@ -167,7 +173,7 @@ taskRoutes.put('/tasks/:id', (req, res) => {
       }
     }
   }
-  task.updatedAt = new Date().toISOString();
+  touchTask(task);
 
   writeData(data);
   res.json(task);
@@ -257,6 +263,7 @@ taskRoutes.post('/tasks/:id/hide', (req, res) => {
     res.status(400).json({ error: 'Provide durationMinutes (15|30|60|120|240) or hideUntilDate (YYYY-MM-DD)' });
     return;
   }
+  touchTask(task);
   clearFocusForTask(data, id);
   writeData(data);
   res.json(task);
@@ -294,6 +301,7 @@ taskRoutes.post('/tasks/:id/focus', (req, res) => {
     return;
   }
 
+  touchTask(task);
   data.settings.focusedTaskId = id;
   writeData(data);
   res.json({ focusedTaskId: data.settings.focusedTaskId });

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -41,6 +41,7 @@ const HIDE_PRESETS: Array<{ minutes: 15 | 30 | 60 | 120 | 240; label: string }> 
   { minutes: 120, label: '2h' },
   { minutes: 240, label: '4h' },
 ];
+const STATUS_PREVIEW_LINES = 4;
 
 function formatHiddenTimestamp(hiddenUntilAt: string | null): string {
   if (!hiddenUntilAt) return 'Hidden temporarily';
@@ -88,10 +89,14 @@ export default function TaskRow({
   const [showHideMenu, setShowHideMenu] = useState(false);
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [hideDateValue, setHideDateValue] = useState('');
+  const [isStatusExpanded, setIsStatusExpanded] = useState(false);
+  const [isStatusOverflowing, setIsStatusOverflowing] = useState(false);
   const skipNextTitleBlurSaveRef = useRef(false);
   const skipNextStatusBlurSaveRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const hideMenuRef = useRef<HTMLDivElement>(null);
+  const statusPreviewRef = useRef<HTMLDivElement>(null);
+  const statusTextRef = useRef<HTMLDivElement>(null);
 
   const tomorrow = useMemo(() => {
     const d = new Date();
@@ -141,6 +146,67 @@ export default function TaskRow({
       autoResizeTextarea(textareaRef.current);
     }
   }, [editingStatus, autoResizeTextarea]);
+
+  const measureStatusOverflow = useCallback(() => {
+    const statusTextEl = statusTextRef.current;
+    if (editingStatus || !statusTextEl || !task.status) {
+      setIsStatusOverflowing(false);
+      if (!task.status) {
+        setIsStatusExpanded(false);
+      }
+      return;
+    }
+
+    const computedStyle = window.getComputedStyle(statusTextEl);
+    let lineHeight = parseFloat(computedStyle.lineHeight);
+    if (Number.isNaN(lineHeight)) {
+      const fontSize = parseFloat(computedStyle.fontSize);
+      lineHeight = Number.isNaN(fontSize) ? 0 : fontSize * 1.5;
+    }
+
+    const maxPreviewHeight = lineHeight * STATUS_PREVIEW_LINES;
+    const contentHeight = statusTextEl.scrollHeight;
+    const overflowing = maxPreviewHeight > 0 && contentHeight > maxPreviewHeight + 1;
+
+    setIsStatusOverflowing(prev => (prev === overflowing ? prev : overflowing));
+    if (!overflowing) {
+      setIsStatusExpanded(false);
+    }
+  }, [editingStatus, task.status]);
+
+  useEffect(() => {
+    measureStatusOverflow();
+
+    if (editingStatus || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const previewEl = statusPreviewRef.current;
+    const textEl = statusTextRef.current;
+    if (!previewEl && !textEl) {
+      return;
+    }
+
+    let frameId = 0;
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(() => {
+        measureStatusOverflow();
+      });
+    });
+
+    if (previewEl) {
+      observer.observe(previewEl);
+    }
+    if (textEl && textEl !== previewEl) {
+      observer.observe(textEl);
+    }
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      observer.disconnect();
+    };
+  }, [editingStatus, measureStatusOverflow]);
 
   // Auto-load blockers when mounting on the blocked tab
   useEffect(() => {
@@ -223,6 +289,10 @@ export default function TaskRow({
     isFocused ? 'task-row-focused' : '',
     recentlyUpdated ? 'task-row-highlight' : '',
   ].filter(Boolean).join(' ');
+  const statusPreviewClasses = [
+    'status-preview',
+    isStatusExpanded ? 'status-preview-expanded' : 'status-preview-collapsed',
+  ].join(' ');
 
   return (
     <div className={rowClasses} style={{ backgroundColor: bgColor }} aria-busy={isPending}>
@@ -244,7 +314,10 @@ export default function TaskRow({
           className="task-title"
           role="button"
           tabIndex={isPending ? -1 : 0}
-          onClick={openTitleEditor}
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest('a')) return;
+            openTitleEditor();
+          }}
           onKeyDown={(e) => {
             if (e.target !== e.currentTarget) return;
             if (e.key === 'Enter' || e.key === ' ') {
@@ -283,7 +356,7 @@ export default function TaskRow({
             <span className="task-title-display">
               <span className="task-id-badge">#{task.id}</span>
               {isFocused && <span className="task-now-pill">Now</span>}
-              <span className="task-title-text">{task.title}</span>
+              <span className="task-title-text">{linkifyText(task.title)}</span>
             </span>
           )}
         </div>
@@ -312,20 +385,20 @@ export default function TaskRow({
             </>
           ) : activeTab === 'hidden' ? (
             <>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
-              <button className="btn btn-sm" onClick={() => onUnhide(task.id)} disabled={isPending} aria-label={`Unhide ${task.title}`}>Unhide</button>
               <button className="btn btn-sm btn-primary" onClick={() => onFocusToggle(task.id, { unhideFirst: true })} disabled={isPending} aria-label={`Focus ${task.title} now`}>Now</button>
+              <button className="btn btn-sm" onClick={() => onUnhide(task.id)} disabled={isPending} aria-label={`Unhide ${task.title}`}>Unhide</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
             </>
           ) : activeTab === 'ideas' ? (
             <>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
               <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
             </>
           ) : activeTab === 'tasks' ? (
             <>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
               <div className="hide-menu" ref={hideMenuRef}>
                 <button
                   className="btn btn-sm btn-primary"
@@ -407,21 +480,21 @@ export default function TaskRow({
                 )}
               </div>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
-              <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
             </>
           ) : activeTab === 'blocked' ? (
             <>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
             </>
           ) : (
             <>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
-              <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
+              <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
             </>
           )}
         </div>
@@ -484,7 +557,31 @@ export default function TaskRow({
         ) : (
           <div className="status-display">
             {task.status ? (
-              <span className="status-text">{linkifyText(task.status)}</span>
+              <>
+                <div
+                  ref={statusPreviewRef}
+                  id={`task-status-preview-${task.id}`}
+                  className={statusPreviewClasses}
+                >
+                  <div ref={statusTextRef} className="status-text">
+                    {linkifyText(task.status)}
+                  </div>
+                </div>
+                {isStatusOverflowing && (
+                  <button
+                    type="button"
+                    className="status-toggle"
+                    aria-controls={`task-status-preview-${task.id}`}
+                    aria-expanded={isStatusExpanded}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsStatusExpanded(prev => !prev);
+                    }}
+                  >
+                    {isStatusExpanded ? 'Less' : 'More'}
+                  </button>
+                )}
+              </>
             ) : (
               <span className="status-placeholder">Click to add status...</span>
             )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -441,6 +441,16 @@ textarea:focus-visible,
   min-width: 0;
 }
 
+.task-title-text a {
+  color: var(--blue-600);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.task-title-text a:hover {
+  color: var(--blue-700);
+}
+
 /* Status section - full width below title row */
 .task-status-section {
   cursor: pointer;
@@ -449,14 +459,33 @@ textarea:focus-visible,
 }
 
 .status-display {
-  white-space: pre-wrap;
-  word-break: break-word;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+.status-preview {
+  width: 100%;
+  overflow: hidden;
+}
+
+.status-preview-collapsed {
+  max-height: calc(0.875rem * 1.5 * 4);
+}
+
+.status-preview-expanded {
+  max-height: none;
 }
 
 .status-text {
   color: var(--text-secondary);
   font-size: 0.875rem;
   line-height: 1.5;
+  display: block;
+  width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .status-text a {
@@ -473,6 +502,22 @@ textarea:focus-visible,
   color: var(--text-placeholder);
   font-size: 0.8125rem;
   font-style: italic;
+}
+
+.status-toggle {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: var(--blue-600);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.status-toggle:hover {
+  color: var(--blue-700);
+  text-decoration: underline;
 }
 
 .status-textarea {


### PR DESCRIPTION
## Summary
- clamp long task descriptions behind an inline More/Less toggle and make URLs in titles clickable
- reorder task-row actions to put Now/Hide/Block/Archive/Done in a consistent left-to-right sequence
- refresh task staleness when hide, block, focus, or archive actions occur and lock hidden-task ordering by earliest unhide time in route tests

## Verification
- npm test
- npm run build