### PR TITLE
Add focus timestamp updates, manual vacation offset, and help docs

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -301,6 +301,10 @@ taskRoutes.post('/tasks/:id/focus', (req, res) => {
     return;
   }
 
+  if (data.settings.focusedTaskId !== null && data.settings.focusedTaskId !== id) {
+    const prev = data.tasks.find(t => t.id === data.settings.focusedTaskId);
+    if (prev) touchTask(prev);
+  }
   touchTask(task);
   data.settings.focusedTaskId = id;
   writeData(data);
@@ -310,6 +314,10 @@ taskRoutes.post('/tasks/:id/focus', (req, res) => {
 // POST /api/tasks/focus/clear
 taskRoutes.post('/tasks/focus/clear', (_req, res) => {
   const data = readData();
+  if (data.settings.focusedTaskId !== null) {
+    const prev = data.tasks.find(t => t.id === data.settings.focusedTaskId);
+    if (prev) touchTask(prev);
+  }
   data.settings.focusedTaskId = null;
   writeData(data);
   res.json({ focusedTaskId: null });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import TaskTable from './components/TaskTable';
 import TaskForm from './components/TaskForm';
 import SettingsPanel from './components/SettingsPanel';
 import VacationNudgeModal from './components/VacationNudgeModal';
-import { getVacationNudgeRecommendation } from './utils/vacationNudge';
+import { getVacationNudgeRecommendation, getManualVacationRecommendation } from './utils/vacationNudge';
 
 interface ToastState {
   id: number;
@@ -518,6 +518,14 @@ export default function App() {
     }
   }, [isImportingData, loadCounts, reload, reloadSettings, showToast]);
 
+  const handleManualVacationNudge = useCallback(() => {
+    const recommendation = getManualVacationRecommendation(allTasks);
+    setVacationSuggestedDays(recommendation.suggestedDays);
+    setVacationInactivityDays(recommendation.inactivityDays);
+    setVacationAnchorUpdatedAt(recommendation.mostRecentActiveUpdatedAt);
+    setShowVacationNudge(true);
+  }, [allTasks]);
+
   const handleApplyVacationNudge = async (days: number) => {
     if (!vacationAnchorUpdatedAt) return;
 
@@ -653,6 +661,7 @@ export default function App() {
             isImportingData={isImportingData}
             onExportData={handleExportData}
             onImportData={handleImportData}
+            onTriggerVacationOffset={handleManualVacationNudge}
           />
         </div>
       </header>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -25,6 +25,7 @@ interface Props {
   isImportingData: boolean;
   onExportData: () => Promise<void>;
   onImportData: (data: StoredAppData) => Promise<void>;
+  onTriggerVacationOffset: () => void;
 }
 
 interface SettingsDraft {
@@ -61,6 +62,7 @@ export default function SettingsPanel({
   isImportingData,
   onExportData,
   onImportData,
+  onTriggerVacationOffset,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -224,7 +226,16 @@ export default function SettingsPanel({
           </label>
           <p className="settings-help">How many prioritized tasks show on Tasks. The rest go to Backlog.</p>
           {errors.topN && <p className="settings-error">{errors.topN}</p>}
-          <p className="settings-help">Vacation adjustments are handled with an inactivity popup when no active task has been updated recently.</p>
+          <div className="settings-vacation-row">
+            <p className="settings-help">Apply a one-time staleness offset if you were away.</p>
+            <button
+              className="btn btn-sm"
+              onClick={onTriggerVacationOffset}
+              disabled={saving}
+            >
+              Apply vacation offset
+            </button>
+          </div>
 
           <div className="settings-updates-section">
             <h3 className="settings-updates-title">App Updates</h3>
@@ -308,6 +319,32 @@ export default function SettingsPanel({
                 onChange={(event) => { void handleImportSelection(event); }}
               />
             </div>
+          </div>
+
+          <div className="settings-updates-section">
+            <h3 className="settings-updates-title">Help &amp; FAQ</h3>
+            <details className="settings-help-details">
+              <summary>How to update Stradl</summary>
+              <div className="settings-help-content">
+                <p><strong>Option 1 — In-app update (managed runtime)</strong></p>
+                <p>
+                  If Stradl is installed via the managed runtime, use the <em>Check for updates</em> button
+                  in the App Updates section above. When a new version is available, click <em>Update now</em>.
+                  The app will download, verify, and apply the update automatically.
+                </p>
+                <p><strong>Option 2 — Manual update (terminal)</strong></p>
+                <p>
+                  Re-run the installer to pull the latest release from GitHub:
+                </p>
+                <pre className="settings-help-code">curl -fsSL https://raw.githubusercontent.com/svakili/stradl/main/scripts/install-stradl.sh | bash</pre>
+                <p>
+                  This downloads the latest tarball, verifies its checksum, extracts the new runtime, and restarts the service.
+                </p>
+                <p className="settings-help-note">
+                  Your task data is never overwritten during updates. A backup snapshot is created automatically before each update.
+                </p>
+              </div>
+            </details>
           </div>
 
           {submitError && <p className="settings-submit-error">{submitError}</p>}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -836,6 +836,49 @@ textarea:focus-visible,
   margin-top: -0.25rem;
 }
 
+/* Help & FAQ */
+.settings-help-details summary {
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 0.25rem 0;
+}
+
+.settings-help-details summary:hover {
+  color: var(--accent);
+}
+
+.settings-help-content {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-top: 0.5rem;
+}
+
+.settings-help-content p {
+  margin-bottom: 0.5rem;
+}
+
+.settings-help-code {
+  display: block;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  padding: 0.5rem;
+  font-size: 0.6875rem;
+  font-family: monospace;
+  overflow-x: auto;
+  margin-bottom: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.settings-help-note {
+  font-style: italic;
+  color: var(--text-muted);
+}
+
 /* Dark Mode Toggle */
 .theme-toggle {
   border: none;

--- a/src/utils/vacationNudge.ts
+++ b/src/utils/vacationNudge.ts
@@ -50,3 +50,38 @@ export function getVacationNudgeRecommendation({
     suggestedDays,
   };
 }
+
+export function getManualVacationRecommendation(
+  tasks: Task[],
+  nowMs: number = Date.now(),
+): VacationNudgeRecommendation {
+  const activeTasks = tasks.filter(t => t.completedAt == null && !t.isArchived);
+
+  let mostRecentUpdatedAt: string | null = null;
+  let mostRecentUpdatedMs = -Infinity;
+  for (const task of activeTasks) {
+    const updatedMs = Date.parse(task.updatedAt);
+    if (!Number.isNaN(updatedMs) && updatedMs > mostRecentUpdatedMs) {
+      mostRecentUpdatedMs = updatedMs;
+      mostRecentUpdatedAt = task.updatedAt;
+    }
+  }
+
+  if (!Number.isFinite(mostRecentUpdatedMs) || !mostRecentUpdatedAt) {
+    return {
+      mostRecentActiveUpdatedAt: new Date(nowMs).toISOString(),
+      inactivityHours: 0,
+      inactivityDays: 1,
+      suggestedDays: 1,
+    };
+  }
+
+  const inactivityHours = (nowMs - mostRecentUpdatedMs) / 3600000;
+  const suggestedDays = Math.max(1, Math.floor(inactivityHours / 24));
+  return {
+    mostRecentActiveUpdatedAt: mostRecentUpdatedAt,
+    inactivityHours,
+    inactivityDays: Math.max(1, suggestedDays),
+    suggestedDays,
+  };
+}


### PR DESCRIPTION
## Summary
- **Focus timestamp updates**: Clicking "Now", "Clear Now", or switching focus between tasks now touches `updatedAt` on the previously-focused task, so sort order within the same priority reflects focus changes
- **Manual vacation offset**: Added an "Apply vacation offset" button in Settings that opens the vacation nudge modal on demand, without waiting for the automatic inactivity detection
- **Help & FAQ section**: Added a collapsible "How to update Stradl" section in Settings covering both in-app (managed runtime) and manual (terminal) update paths

## Test plan
- [ ] Click "Now" on a task → verify `updatedAt` bumps and sort order updates
- [ ] Click "Clear Now" → verify the previously-focused task's `updatedAt` bumps
- [ ] Click "Now" on task A, then "Now" on task B → verify task A's `updatedAt` was touched
- [ ] Open Settings → click "Apply vacation offset" → verify the vacation nudge modal opens
- [ ] Open Settings → expand "How to update Stradl" → verify both update options are shown
- [ ] Run `npx tsc --noEmit` and `npx tsc -p tsconfig.server.json --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)