### PR TITLE
Add recurring tasks support

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -120,13 +120,14 @@ taskRoutes.get('/tasks', (req, res) => {
 // POST /api/tasks
 taskRoutes.post('/tasks', (req, res) => {
   const data = readData();
-  const { title, status, priority } = req.body;
+  const { title, status, priority, recurrence } = req.body;
 
   if (!title || typeof title !== 'string') {
     res.status(400).json({ error: 'title is required' });
     return;
   }
 
+  const validRecurrences = ['daily', 'weekly', 'biweekly', 'monthly'];
   const now = new Date().toISOString();
   const task: Task = {
     id: data.nextTaskId++,
@@ -138,6 +139,7 @@ taskRoutes.post('/tasks', (req, res) => {
     completedAt: null,
     isArchived: false,
     hiddenUntilAt: null,
+    recurrence: validRecurrences.includes(recurrence) ? recurrence : null,
   };
 
   data.tasks.push(task);
@@ -156,10 +158,14 @@ taskRoutes.put('/tasks/:id', (req, res) => {
     return;
   }
 
-  const { title, status, priority, isArchived } = req.body;
+  const { title, status, priority, isArchived, recurrence } = req.body;
   if (title !== undefined) task.title = title.trim();
   if (status !== undefined) task.status = typeof status === 'string' ? status.trim() : status;
   if (priority !== undefined) task.priority = priority || null;
+  if (recurrence !== undefined) {
+    const validRecurrences = ['daily', 'weekly', 'biweekly', 'monthly'];
+    task.recurrence = validRecurrences.includes(recurrence) ? recurrence : null;
+  }
   if (isArchived !== undefined) {
     task.isArchived = isArchived;
     // Resolve blockers that depend on this task when archiving
@@ -191,8 +197,18 @@ taskRoutes.post('/tasks/:id/complete', (req, res) => {
   }
 
   const now = new Date().toISOString();
-  task.completedAt = now;
-  task.updatedAt = now;
+
+  if (task.recurrence) {
+    // Recurring task: hide until next occurrence instead of completing
+    const intervalDays: Record<string, number> = { daily: 1, weekly: 7, biweekly: 14, monthly: 30 };
+    const ms = intervalDays[task.recurrence] * 24 * 60 * 60 * 1000;
+    task.hiddenUntilAt = new Date(Date.now() + ms).toISOString();
+    task.completedAt = null;
+    task.updatedAt = now;
+  } else {
+    task.completedAt = now;
+    task.updatedAt = now;
+  }
 
   // Resolve blockers that depend on this task
   for (const blocker of data.blockers) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19,6 +19,8 @@ interface ResolveStoragePathsOptions {
   homeDir?: string;
 }
 
+export type Recurrence = 'daily' | 'weekly' | 'biweekly' | 'monthly' | null;
+
 export interface Task {
   id: number;
   title: string;
@@ -29,6 +31,7 @@ export interface Task {
   completedAt: string | null;
   isArchived: boolean;
   hiddenUntilAt: string | null;
+  recurrence: Recurrence;
 }
 
 export interface Blocker {
@@ -252,6 +255,10 @@ function isPriority(value: unknown): value is Task['priority'] {
   return value === 'P0' || value === 'P1' || value === 'P2' || value === null;
 }
 
+function isRecurrence(value: unknown): value is Recurrence {
+  return value === 'daily' || value === 'weekly' || value === 'biweekly' || value === 'monthly' || value === null;
+}
+
 function coerceTask(value: unknown, index: number): Task {
   if (!isRecord(value)) {
     throw new Error(`Task at index ${index} is invalid.`);
@@ -283,6 +290,7 @@ function coerceTask(value: unknown, index: number): Task {
     completedAt,
     isArchived: typeof value.isArchived === 'boolean' ? value.isArchived : isDeleted,
     hiddenUntilAt,
+    recurrence: isRecurrence(value.recurrence) ? value.recurrence : null,
   };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,7 +263,7 @@ export default function App() {
     }
   }, [showToast, markRecentlyUpdated, reloadSettings]);
 
-  const handleCreate = async (data: { title: string; status?: string; priority?: string | null }) => {
+  const handleCreate = async (data: { title: string; status?: string; priority?: string | null; recurrence?: string | null }) => {
     try {
       await create(data);
       await loadCounts();
@@ -274,7 +274,7 @@ export default function App() {
     }
   };
 
-  const handleUpdate = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => {
+  const handleUpdate = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'recurrence'>>) => {
     const undoAction = data.isArchived !== undefined
       ? () => {
           void handleUpdate(id, { isArchived: !data.isArchived });
@@ -299,11 +299,19 @@ export default function App() {
   };
 
   const handleComplete = async (id: number) => {
+    const RECURRENCE_LABELS: Record<string, string> = { daily: '1 day', weekly: '1 week', biweekly: '2 weeks', monthly: '30 days' };
     await runTaskAction(id, async () => {
-      await complete(id);
+      const result = await complete(id);
       await loadCounts();
-    }, 'Task completed.', () => {
-      void handleUncomplete(id);
+      if (result.recurrence && !result.completedAt) {
+        showToast(`Task cycled. Returns in ${RECURRENCE_LABELS[result.recurrence]}.`, 'success', () => {
+          void handleUnhide(id);
+        });
+      } else {
+        showToast('Task completed.', 'success', () => {
+          void handleUncomplete(id);
+        });
+      }
     });
   };
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,10 +38,10 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
 export const fetchTasks = (tab: TabName) =>
   request<Task[]>(`/tasks?tab=${tab}`);
 
-export const createTask = (data: { title: string; status?: string; priority?: string | null }) =>
+export const createTask = (data: { title: string; status?: string; priority?: string | null; recurrence?: string | null }) =>
   request<Task>('/tasks', { method: 'POST', body: JSON.stringify(data) });
 
-export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) =>
+export const updateTask = (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'recurrence'>>) =>
   request<Task>(`/tasks/${id}`, { method: 'PUT', body: JSON.stringify(data) });
 
 export const completeTask = (id: number) =>

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -5,7 +5,7 @@ import type { TabName } from '../types';
 interface Props {
   activeTab: TabName;
   titleInputRef?: RefObject<HTMLInputElement>;
-  onCreate: (data: { title: string; status?: string; priority?: string | null }) => Promise<void>;
+  onCreate: (data: { title: string; status?: string; priority?: string | null; recurrence?: string | null }) => Promise<void>;
 }
 
 export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) {
@@ -13,6 +13,7 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
   const [status, setStatus] = useState('');
   const [showStatus, setShowStatus] = useState(false);
   const [priority, setPriority] = useState<string>('P1');
+  const [recurrence, setRecurrence] = useState<string>('');
   const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -26,9 +27,11 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
         title: title.trim(),
         ...(status.trim() ? { status: status.trim() } : {}),
         priority: isIdea ? null : priority,
+        ...(recurrence ? { recurrence } : {}),
       });
       setTitle('');
       setStatus('');
+      setRecurrence('');
       setShowStatus(false);
     } catch {
       // Error feedback is handled at the app level.
@@ -63,6 +66,19 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
             <option value="P2">P2</option>
           </select>
         )}
+        <select
+          value={recurrence}
+          onChange={e => setRecurrence(e.target.value)}
+          className="task-form-recurrence"
+          aria-label="New task recurrence"
+          disabled={submitting}
+        >
+          <option value="">Once</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="biweekly">Biweekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
         <button
           type="button"
           className={`btn task-form-status-toggle${showStatus ? ' active' : ''}`}

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -16,7 +16,7 @@ interface Props {
   blockers: Blocker[];
   activeTab: TabName;
   recentlyUpdated?: boolean;
-  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => Promise<void>;
+  onUpdate: (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'recurrence'>>) => Promise<void>;
   onComplete: (id: number) => Promise<void>;
   onHide: (id: number, durationMinutes: 15 | 30 | 60 | 120 | 240) => Promise<void>;
   onHideUntilDate: (id: number, date: string) => Promise<void>;
@@ -310,6 +310,22 @@ export default function TaskRow({
           <option value="P2">P2</option>
         </select>
 
+        {(activeTab === 'tasks' || activeTab === 'backlog' || activeTab === 'ideas' || activeTab === 'hidden') && (
+          <select
+            value={task.recurrence || ''}
+            onChange={e => onUpdate(task.id, { recurrence: (e.target.value || null) as Task['recurrence'] })}
+            className="recurrence-select"
+            aria-label={`Recurrence for ${task.title}`}
+            disabled={isPending}
+          >
+            <option value="">Once</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="biweekly">Biweekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        )}
+
         <div
           className="task-title"
           role="button"
@@ -356,6 +372,7 @@ export default function TaskRow({
             <span className="task-title-display">
               <span className="task-id-badge">#{task.id}</span>
               {isFocused && <span className="task-now-pill">Now</span>}
+              {task.recurrence && <span className="task-recurrence-badge">{task.recurrence}</span>}
               <span className="task-title-text">{linkifyText(task.title)}</span>
             </span>
           )}
@@ -388,13 +405,13 @@ export default function TaskRow({
               <button className="btn btn-sm btn-primary" onClick={() => onFocusToggle(task.id, { unhideFirst: true })} disabled={isPending} aria-label={`Focus ${task.title} now`}>Now</button>
               <button className="btn btn-sm" onClick={() => onUnhide(task.id)} disabled={isPending} aria-label={`Unhide ${task.title}`}>Unhide</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>{task.recurrence ? 'Cycle' : 'Done'}</button>
             </>
           ) : activeTab === 'ideas' ? (
             <>
               <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>{task.recurrence ? 'Cycle' : 'Done'}</button>
             </>
           ) : activeTab === 'tasks' ? (
             <>
@@ -481,20 +498,20 @@ export default function TaskRow({
               </div>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>{task.recurrence ? 'Cycle' : 'Done'}</button>
             </>
           ) : activeTab === 'blocked' ? (
             <>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>{task.recurrence ? 'Cycle' : 'Done'}</button>
             </>
           ) : (
             <>
               <button className="btn btn-sm" onClick={() => onFocusToggle(task.id)} disabled={isPending} aria-label={`Toggle focus for ${task.title}`}>{isFocused ? 'Clear Now' : 'Now'}</button>
               <button className="btn btn-sm" onClick={toggleBlockers} disabled={isPending} aria-label={`Manage blockers for ${task.title}`}>Block</button>
               <button className="btn btn-sm" onClick={() => onUpdate(task.id, { isArchived: true })} disabled={isPending} aria-label={`Archive ${task.title}`}>Archive</button>
-              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>Done</button>
+              <button className="btn btn-sm btn-success" onClick={() => onComplete(task.id)} disabled={isPending} aria-label={`Mark ${task.title} as done`}>{task.recurrence ? 'Cycle' : 'Done'}</button>
             </>
           )}
         </div>

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -28,19 +28,20 @@ export function useTasks(tab: TabName) {
     return () => window.clearInterval(intervalId);
   }, [reload]);
 
-  const create = async (data: { title: string; status?: string; priority?: string | null }) => {
+  const create = async (data: { title: string; status?: string; priority?: string | null; recurrence?: string | null }) => {
     await api.createTask(data);
     await reload();
   };
 
-  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived'>>) => {
+  const update = async (id: number, data: Partial<Pick<Task, 'title' | 'status' | 'priority' | 'isArchived' | 'recurrence'>>) => {
     await api.updateTask(id, data);
     await reload();
   };
 
-  const complete = async (id: number) => {
-    await api.completeTask(id);
+  const complete = async (id: number): Promise<Task> => {
+    const result = await api.completeTask(id);
     await reload();
+    return result;
   };
 
   const uncomplete = async (id: number) => {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -260,7 +260,8 @@ textarea:focus-visible,
   box-shadow: 0 0 0 2px var(--blue-ring);
 }
 
-.task-form-priority {
+.task-form-priority,
+.task-form-recurrence {
   padding: 0.5rem;
   border: 1px solid var(--border-default);
   border-radius: 0.375rem;
@@ -433,6 +434,17 @@ textarea:focus-visible,
   text-transform: uppercase;
   box-shadow: 0 1px 2px var(--shadow-sm);
 }
+.task-recurrence-badge {
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-input);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 0.125rem 0.375rem;
+  text-transform: capitalize;
+}
 .task-title-text {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -561,7 +573,8 @@ textarea:focus-visible,
   color: var(--text-primary);
 }
 
-.priority-select {
+.priority-select,
+.recurrence-select {
   padding: 0.25rem;
   border: 1px solid var(--border-default);
   border-radius: 0.25rem;
@@ -1191,7 +1204,8 @@ textarea:focus-visible,
     margin-top: 0.375rem;
   }
 
-  .priority-select {
+  .priority-select,
+  .recurrence-select {
     width: 100%;
   }
 
@@ -1222,7 +1236,9 @@ textarea:focus-visible,
   .btn,
   .task-form-input,
   .task-form-priority,
+  .task-form-recurrence,
   .priority-select,
+  .recurrence-select,
   .settings-field input,
   .blocker-form select,
   .blocker-form input {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Recurrence = 'daily' | 'weekly' | 'biweekly' | 'monthly' | null;
+
 export interface Task {
   id: number;
   title: string;
@@ -8,6 +10,7 @@ export interface Task {
   completedAt: string | null;
   isArchived: boolean;
   hiddenUntilAt: string | null;
+  recurrence: Recurrence;
 }
 
 export interface Blocker {


### PR DESCRIPTION
## Summary
- Adds a `recurrence` field (`daily`/`weekly`/`biweekly`/`monthly`) to tasks
- Completing a recurring task hides it for the next interval instead of permanently completing it — prevents accidentally losing recurrence
- Shows "Cycle" button instead of "Done" for recurring tasks, with a recurrence badge on the title
- Recurrence selector available on task rows and the creation form
- To permanently complete a recurring task: set recurrence to "Once" first, then complete

## Test plan
- [ ] Create a task with "Weekly" recurrence, click "Cycle" → verify it moves to Hidden tab with ~7 day hide duration
- [ ] Verify Completed count does not increase when cycling a recurring task
- [ ] Change a recurring task to "Once", complete it → verify it goes to Completed tab normally
- [ ] Verify non-recurring tasks still show "Done" and complete as before
- [ ] Verify recurrence persists across page reloads (stored in JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)