### PR TITLE
Show exact completion date on Completed tab

### DIFF
--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -278,7 +278,7 @@ export default function TaskRow({
   };
 
   const timestamp = activeTab === 'completed' && task.completedAt
-    ? `Completed ${relativeTime(task.completedAt)}`
+    ? `Completed ${relativeTime(task.completedAt)} · ${new Date(task.completedAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`
     : activeTab === 'hidden'
       ? formatHiddenTimestamp(task.hiddenUntilAt)
       : `Updated ${relativeTime(task.updatedAt)}`;


### PR DESCRIPTION
## Summary
- Display the exact completion date alongside relative time for completed tasks on the Completed tab
- Format: "Completed 1w ago · Mar 18, 2026" instead of just "Completed 1w ago"
- Tasks remain sorted from most recently completed to oldest (already handled server-side)

## Test plan
- [ ] Navigate to the Completed tab
- [ ] Verify each task shows both relative time and exact date (e.g. "Completed 1w ago · Mar 18, 2026")
- [ ] Verify tasks are ordered from most recently completed to oldest

🤖 Generated with [Claude Code](https://claude.com/claude-code)