### PR TITLE
Add P3 priority, fix Hide menu stacking, scope tab counts to search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ React Components → Custom Hooks (useTasks/useBlockers/useSettings)
 ### Tab System & Task Filtering
 
 All tab filtering happens server-side in `server/routes/tasks.ts`:
-- **Tasks**: Top N prioritized tasks (P0→P1→P2, then by updatedAt)
+- **Tasks**: Top N prioritized tasks (P0→P1→P2→P3, then by updatedAt)
 - **Backlog**: Overflow beyond top N, same sort order
 - **Ideas**: Tasks with `priority === null`
 - **Blocked**: Tasks with unresolved blockers (auto-unblock runs on every GET)
@@ -61,7 +61,7 @@ The `getPrioritizedTasks()` helper in `server/routes/tasks.ts` is shared between
 
 - **Inline editing**: TaskRow uses local state (`useState`) for title/status editing, synced back via `onUpdate` prop
 - **Status field**: Multi-line textarea with auto-resize, URL auto-linking via `src/utils/linkify.tsx`
-- **Row coloring**: P0=red (`#fee2e2`), P1=yellow (`#fef9c3`), P2=green (`#dcfce7`), Ideas=gray, Stale=purple (`#e9d5ff`)
+- **Row coloring**: P0=red (`#fee2e2`), P1=yellow (`#fef9c3`), P2=green (`#dcfce7`), P3=blue (`#dbeafe`), Ideas=gray, Stale=purple (`#e9d5ff`)
 - **Staleness**: `src/utils/staleness.ts` compares `updatedAt` against threshold + vacation offset
 - **Counts refresh**: `App.tsx` loads counts for all 6 tabs after every mutation via `loadCounts()`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/svakili/stradl/actions/workflows/ci.yml/badge.svg)](https://github.com/svakili/stradl/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-A single-user local task management app for multitasking. Tracks tasks with priorities (P0/P1/P2/Ideas), free-text statuses, blocking relationships, and staleness indicators. The same React UI can run as a browser/PWA build or as a managed local runtime on macOS with one-click updates.
+A single-user local task management app for multitasking. Tracks tasks with priorities (P0/P1/P2/P3/Ideas), free-text statuses, blocking relationships, and staleness indicators. The same React UI can run as a browser/PWA build or as a managed local runtime on macOS with one-click updates.
 
 > Project status: early-stage. Current contribution scope is intentionally narrow to docs and small fixes. See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -127,8 +127,8 @@ The repo-based LaunchAgent mode does not enable one-click self-update. The updat
 
 ## Features
 
-- **Priority tabs** -- Tasks (P0/P1/P2), Ideas (no priority), Blocked, Archive
-- **Row colors** -- P0 red, P1 yellow, P2 green, Ideas gray, Stale purple
+- **Priority tabs** -- Tasks (P0/P1/P2/P3), Ideas (no priority), Blocked, Archive
+- **Row colors** -- P0 red, P1 yellow, P2 green, P3 blue, Ideas gray, Stale purple
 - **Inline editing** -- Click title or status to edit in place
 - **Blocking** -- Block a task on another task or until a date; auto-unblocks when the condition is met
 - **Staleness** -- Tasks not updated within the threshold turn purple

--- a/server/__tests__/task-logic.test.ts
+++ b/server/__tests__/task-logic.test.ts
@@ -37,9 +37,10 @@ describe('isTaskHiddenNow', () => {
 });
 
 describe('PRIORITY_ORDER', () => {
-  it('orders P0 < P1 < P2', () => {
+  it('orders P0 < P1 < P2 < P3', () => {
     expect(PRIORITY_ORDER['P0']).toBeLessThan(PRIORITY_ORDER['P1']);
     expect(PRIORITY_ORDER['P1']).toBeLessThan(PRIORITY_ORDER['P2']);
+    expect(PRIORITY_ORDER['P2']).toBeLessThan(PRIORITY_ORDER['P3']);
   });
 });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -25,7 +25,7 @@ export interface Task {
   id: number;
   title: string;
   status: string;
-  priority: 'P0' | 'P1' | 'P2' | null;
+  priority: 'P0' | 'P1' | 'P2' | 'P3' | null;
   createdAt: string;
   updatedAt: string;
   completedAt: string | null;
@@ -252,7 +252,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isPriority(value: unknown): value is Task['priority'] {
-  return value === 'P0' || value === 'P1' || value === 'P2' || value === null;
+  return value === 'P0' || value === 'P1' || value === 'P2' || value === 'P3' || value === null;
 }
 
 function isRecurrence(value: unknown): value is Recurrence {

--- a/server/task-logic.ts
+++ b/server/task-logic.ts
@@ -1,6 +1,6 @@
 import type { AppData, Task } from './storage.js';
 
-export const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2 };
+export const PRIORITY_ORDER: Record<string, number> = { P0: 0, P1: 1, P2: 2, P3: 3 };
 
 export function autoUnblock(data: AppData): boolean {
   const now = new Date();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ function sleep(ms: number): Promise<void> {
 
 export default function App() {
   const [activeTab, setActiveTab] = useState<TabName>('tasks');
-  const [counts, setCounts] = useState<Record<TabName, number>>({ tasks: 0, backlog: 0, ideas: 0, blocked: 0, hidden: 0, completed: 0, archive: 0 });
+  const [tabTasks, setTabTasks] = useState<Record<TabName, Task[]>>({ tasks: [], backlog: [], ideas: [], blocked: [], hidden: [], completed: [], archive: [] });
   const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [toasts, setToasts] = useState<ToastState[]>([]);
   const [pendingActionByTaskId, setPendingActionByTaskId] = useState<Record<number, boolean>>({});
@@ -100,13 +100,19 @@ export default function App() {
   }, []);
 
   // Filter tasks by search query
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery.trim()) return tasks;
-    const q = searchQuery.toLowerCase();
-    return tasks.filter(t =>
-      t.title.toLowerCase().includes(q) || t.status.toLowerCase().includes(q)
-    );
-  }, [tasks, searchQuery]);
+  const matchesSearch = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return (_t: Task) => true;
+    return (t: Task) => t.title.toLowerCase().includes(q) || t.status.toLowerCase().includes(q);
+  }, [searchQuery]);
+  const filteredTasks = useMemo(() => tasks.filter(matchesSearch), [tasks, matchesSearch]);
+  const counts = useMemo<Record<TabName, number>>(() => {
+    const result: Record<TabName, number> = { tasks: 0, backlog: 0, ideas: 0, blocked: 0, hidden: 0, completed: 0, archive: 0 };
+    TAB_ORDER.forEach(t => {
+      result[t] = tabTasks[t].filter(matchesSearch).length;
+    });
+    return result;
+  }, [tabTasks, matchesSearch]);
   const hasActiveSearch = searchQuery.trim().length > 0;
 
   const showToast = useCallback((
@@ -200,9 +206,9 @@ export default function App() {
 
   const loadCounts = useCallback(async () => {
     const results = await Promise.all(TAB_ORDER.map(t => api.fetchTasks(t)));
-    const newCounts: Record<TabName, number> = { tasks: 0, backlog: 0, ideas: 0, blocked: 0, hidden: 0, completed: 0, archive: 0 };
-    TAB_ORDER.forEach((t, i) => { newCounts[t] = results[i].length; });
-    setCounts(newCounts);
+    const newTabTasks: Record<TabName, Task[]> = { tasks: [], backlog: [], ideas: [], blocked: [], hidden: [], completed: [], archive: [] };
+    TAB_ORDER.forEach((t, i) => { newTabTasks[t] = results[i]; });
+    setTabTasks(newTabTasks);
 
     // Collect all tasks for blocker form dropdowns
     const all = new Map<number, Task>();

--- a/src/components/BlockerForm.tsx
+++ b/src/components/BlockerForm.tsx
@@ -12,6 +12,7 @@ const PRIORITY_RANK: Record<NonNullable<Task['priority']>, number> = {
   P0: 0,
   P1: 1,
   P2: 2,
+  P3: 3,
 };
 
 function parseTaskIdInput(value: string): number | null {
@@ -21,8 +22,8 @@ function parseTaskIdInput(value: string): number | null {
 }
 
 function compareTasks(a: Task, b: Task): number {
-  const aPriorityRank = a.priority ? PRIORITY_RANK[a.priority] : 3;
-  const bPriorityRank = b.priority ? PRIORITY_RANK[b.priority] : 3;
+  const aPriorityRank = a.priority ? PRIORITY_RANK[a.priority] : 4;
+  const bPriorityRank = b.priority ? PRIORITY_RANK[b.priority] : 4;
   if (aPriorityRank !== bPriorityRank) return aPriorityRank - bPriorityRank;
 
   const aUpdated = new Date(a.updatedAt).getTime();

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -64,6 +64,7 @@ export default function TaskForm({ activeTab, titleInputRef, onCreate }: Props) 
             <option value="P0">P0</option>
             <option value="P1">P1</option>
             <option value="P2">P2</option>
+            <option value="P3">P3</option>
           </select>
         )}
         <select

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -33,6 +33,7 @@ const ROW_COLORS: Record<string, string> = {
   P0: 'var(--row-p0)',
   P1: 'var(--row-p1)',
   P2: 'var(--row-p2)',
+  P3: 'var(--row-p3)',
 };
 const HIDE_PRESETS: Array<{ minutes: 15 | 30 | 60 | 120 | 240; label: string }> = [
   { minutes: 15, label: '15m' },
@@ -288,6 +289,7 @@ export default function TaskRow({
     isPending ? 'task-row-pending' : '',
     isFocused ? 'task-row-focused' : '',
     recentlyUpdated ? 'task-row-highlight' : '',
+    showHideMenu ? 'task-row--menu-open' : '',
   ].filter(Boolean).join(' ');
   const statusPreviewClasses = [
     'status-preview',
@@ -308,6 +310,7 @@ export default function TaskRow({
           <option value="P0">P0</option>
           <option value="P1">P1</option>
           <option value="P2">P2</option>
+          <option value="P3">P3</option>
         </select>
 
         {(activeTab === 'tasks' || activeTab === 'backlog' || activeTab === 'ideas' || activeTab === 'hidden') && (

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,6 +31,7 @@
   --row-p0: #fee2e2;
   --row-p1: #fef9c3;
   --row-p2: #dcfce7;
+  --row-p3: #dbeafe;
   --row-idea: #f3f4f6;
   --row-stale: #e9d5ff;
   --blocker-bg: rgba(255,255,255,0.6);
@@ -76,6 +77,7 @@
   --row-p0: #3b1a1a;
   --row-p1: #3b3510;
   --row-p2: #1a3b2a;
+  --row-p3: #1a2a3b;
   --row-idea: #1f2937;
   --row-stale: #2e1a4a;
   --blocker-bg: rgba(55, 65, 81, 0.6);
@@ -393,6 +395,11 @@ textarea:focus-visible,
 .task-row:hover {
   box-shadow: var(--shadow-hover);
   transform: translateY(-1px);
+}
+
+.task-row--menu-open {
+  position: relative;
+  z-index: 20;
 }
 
 .task-row-focused {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface Task {
   id: number;
   title: string;
   status: string;
-  priority: 'P0' | 'P1' | 'P2' | null;
+  priority: 'P0' | 'P1' | 'P2' | 'P3' | null;
   createdAt: string;
   updatedAt: string;
   completedAt: string | null;


### PR DESCRIPTION
## Summary
- Add P3 as a new lowest priority tier alongside P0/P1/P2/Ideas, with a soft blue row color in both light and dark themes. Updates the Task type on frontend and server, storage validation, PRIORITY_ORDER, BlockerForm ranking, TaskForm/TaskRow select options, row coloring, docs, and the PRIORITY_ORDER test.
- Fix the Hide snooze popover being occluded by neighboring task rows. The hover `transform` on `.task-row` was creating a new stacking context that trapped the popover; the row now gets `position: relative` and a higher `z-index` while the menu is open so the popover paints cleanly above sibling rows, no portal required.
- Tab count badges now reflect the active search query. Per-tab task lists already fetched by `loadCounts` are stored in state, and counts are derived via `useMemo` using the same title/status filter as the active tab's visible rows. No new API calls and no debouncing.

## Test plan
- [x] `npx tsc --noEmit` (frontend)
- [x] `npx tsc -p tsconfig.server.json --noEmit` (server)
- [x] `npm test` — all 137 server tests pass
- [x] `npm run build` — frontend + server build clean
- [x] Hide menu verified in preview: with artificially short rows the popover overlaps 5 sibling rows, and hit-testing at 5 y-positions inside the overlap region all land inside `.hide-menu-popover` (not the underlying rows). Screenshot confirms clean rendering.
- [x] P3 priority verified in preview: all priority selects expose P3, setting a task to P3 round-trips through the API, the row renders with `#dbeafe` blue, and the task sorts after all P1 rows in the Tasks tab.
- [x] Search counts verified in preview: baseline counts `[4, 3, 3, 0, 2, 5, 6]`; with query `test` counts become `[0, 2, 1, 0, 1, 5, 0]`, matching a manual filter over the unfiltered `/api/tasks` responses; clearing the search restores baseline; the active tab's visible row count matches its badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
