### PR TITLE
Cycle recurring tasks to start of target day

### DIFF
--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -201,8 +201,10 @@ taskRoutes.post('/tasks/:id/complete', (req, res) => {
   if (task.recurrence) {
     // Recurring task: hide until next occurrence instead of completing
     const intervalDays: Record<string, number> = { daily: 1, weekly: 7, biweekly: 14, monthly: 30 };
-    const ms = intervalDays[task.recurrence] * 24 * 60 * 60 * 1000;
-    task.hiddenUntilAt = new Date(Date.now() + ms).toISOString();
+    const next = new Date();
+    next.setDate(next.getDate() + intervalDays[task.recurrence]);
+    next.setHours(0, 0, 0, 0);
+    task.hiddenUntilAt = next.toISOString();
     task.completedAt = null;
     task.updatedAt = now;
   } else {


### PR DESCRIPTION
## Summary
- When a recurring task is cycled (completed), `hiddenUntilAt` now snaps to local midnight of the target day instead of `now + N×24h`. A daily task cycled at 4 PM becomes visible again at midnight, not 4 PM the next day.

## Test plan
- [x] `npx tsc -p tsconfig.server.json --noEmit`
- [x] Manual: created a daily recurring task, completed it at 4:22 PM PDT, confirmed `hiddenUntilAt` = `2026-04-18T07:00:00.000Z` (Sat 00:00 local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)